### PR TITLE
Prevent setting progress bar on player close if video is watched.

### DIFF
--- a/tubearchivist/static/script.js
+++ b/tubearchivist/static/script.js
@@ -444,7 +444,7 @@ function getVideoPlayerDuration() {
 function getVideoPlayerWatchStatus() {
     var videoId = getVideoPlayerVideoId();
     var watched = false;
-    if(document.getElementById(videoId).className != "unseen-icon") {
+    if(document.getElementById(videoId) != null && document.getElementById(videoId).className != "unseen-icon") {
         watched = true;
     }
     return watched;
@@ -608,8 +608,10 @@ function removePlayer() {
 function setProgressBar(videoId, currentTime, duration) {
     progressBar = document.getElementById("progress-" + videoId);
     progressBarWidth = (currentTime / duration) * 100 + "%";
-    if (progressBar) {
+    if (progressBar && !getVideoPlayerWatchStatus()) {
         progressBar.style.width = progressBarWidth;
+    } else if (progressBar) {
+        progressBar.style.width = "0%";
     }
 }
 


### PR DESCRIPTION
Added check to `setProgressBar()` that will set progress bar width to 0 if the video is marked as watched reguardless of time and duration passed to the function.
Fixes bug where on player close the bar could be set even if the video is watched.