### PR TITLE
Fix #241 Use title/uploader for embedded metadata not Content ID

### DIFF
--- a/tubearchivist/home/src/download/yt_dlp_handler.py
+++ b/tubearchivist/home/src/download/yt_dlp_handler.py
@@ -313,6 +313,17 @@ class VideoDownloader:
                     "add_metadata": True,
                 }
             )
+            postprocessors.append(
+                {
+                    "key": "MetadataFromField",
+                    "formats": [
+                        "%(title)s:%(meta_title)s",
+                        "%(uploader)s:%(meta_artist)s",
+                        ":(?P<album>)",
+                    ],
+                    "when": "pre_process",
+                }
+            )
 
         if self.config["downloads"]["add_thumbnail"]:
             postprocessors.append(


### PR DESCRIPTION
When `yt_dlp` downloads a video which has Content ID data (e.g. a song which appears in the video), the metadata embedded in the file on disk will contain the details from the song and not the video downloaded.

This applies the [suggested workaround](https://github.com/yt-dlp/yt-dlp/issues/3146#issuecomment-1075666330) from the `yt_dlp` manual to ensure that the title and uploader are those of the video, not the Content ID.

In addition it unsets the album metadata property which is an additional Content ID field which is not set on videos without Content ID.

This change means that the metadata in the Tubearchivist UI and the metadata embedded in the file align.