### PR TITLE
Fix repeated superuser creations after rename/removal

### DIFF
--- a/docker_assets/run.sh
+++ b/docker_assets/run.sh
@@ -43,9 +43,17 @@ if [[ -f .superuser_created ]]; then
     echo -e "\e[33;1m[WARNING]\e[0m This is not the first run! Skipping" \
         "superuser creation.\nTo force it, remove $(pwd)/.superuser_created"
 else
-    export DJANGO_SUPERUSER_PASSWORD=$TA_PASSWORD && \
-        python manage.py createsuperuser --noinput --name "$TA_USERNAME" && \
-        touch .superuser_created
+    export DJANGO_SUPERUSER_PASSWORD=$TA_PASSWORD
+    output="$(python manage.py createsuperuser --noinput --name "$TA_USERNAME" 2>&1)"
+
+    case "$output" in
+        *"Superuser created successfully"*)
+            echo "$output" && touch .superuser_created ;;
+        *"That name is already taken."*)
+            echo "Superuser already exists. Creation will be skipped on next start."
+            touch .superuser_created ;;
+        *) echo "$output" && exit 1
+    esac
 fi
 
 python manage.py collectstatic --noinput -c

--- a/docker_assets/run.sh
+++ b/docker_assets/run.sh
@@ -5,11 +5,10 @@ if [[ -z "$ELASTIC_USER" ]]; then
     export ELASTIC_USER=elastic
 fi
 
+checkfile=/cache/.superuser_created
 required="Missing required environment variable"
-if [[ ! -f .superuser_created ]]; then
-    : "${TA_USERNAME:?$required}"
-    : "${TA_PASSWORD:?$required}"
-fi
+[[ -f $checkfile ]] || : "${TA_USERNAME:?$required}"
+: "${TA_PASSWORD:?$required}"
 : "${ELASTIC_PASSWORD:?$required}"
 
 # ugly nginx and uwsgi port overwrite with env vars
@@ -39,19 +38,19 @@ done
 python manage.py makemigrations
 python manage.py migrate
 
-if [[ -f .superuser_created ]]; then
+if [[ -f $checkfile ]]; then
     echo -e "\e[33;1m[WARNING]\e[0m This is not the first run! Skipping" \
-        "superuser creation.\nTo force it, remove $(pwd)/.superuser_created"
+        "superuser creation.\nTo force it, remove $checkfile"
 else
     export DJANGO_SUPERUSER_PASSWORD=$TA_PASSWORD
     output="$(python manage.py createsuperuser --noinput --name "$TA_USERNAME" 2>&1)"
 
     case "$output" in
         *"Superuser created successfully"*)
-            echo "$output" && touch .superuser_created ;;
+            echo "$output" && touch $checkfile ;;
         *"That name is already taken."*)
             echo "Superuser already exists. Creation will be skipped on next start."
-            touch .superuser_created ;;
+            touch $checkfile ;;
         *) echo "$output" && exit 1
     esac
 fi

--- a/docker_assets/run.sh
+++ b/docker_assets/run.sh
@@ -5,8 +5,9 @@ if [[ -z "$ELASTIC_USER" ]]; then
     export ELASTIC_USER=elastic
 fi
 
-lockfile=/cache/initsu.lock
-[[ -d /cache ]] || lockfile=initsu.lock
+cachedir=/cache
+[[ -d $cachedir ]] || cachedir=.
+lockfile=${cachedir}/initsu.lock
 
 required="Missing required environment variable"
 [[ -f $lockfile ]] || : "${TA_USERNAME:?$required}"
@@ -61,5 +62,5 @@ python manage.py collectstatic --noinput -c
 nginx &
 celery -A home.tasks worker --loglevel=INFO &
 celery -A home beat --loglevel=INFO \
-    -s "${BEAT_SCHEDULE_PATH:-/cache/celerybeat-schedule}" &
+    -s "${BEAT_SCHEDULE_PATH:-${cachedir}/celerybeat-schedule}" &
 uwsgi --ini uwsgi.ini

--- a/docker_assets/run.sh
+++ b/docker_assets/run.sh
@@ -8,7 +8,7 @@ fi
 required="Missing required environment variable"
 if [[ ! -f .superuser_created ]]; then
     : "${TA_USERNAME:?$required}"
-    : "${TA_PASSWORD?$required}"
+    : "${TA_PASSWORD:?$required}"
 fi
 : "${ELASTIC_PASSWORD:?$required}"
 

--- a/docker_assets/run.sh
+++ b/docker_assets/run.sh
@@ -5,13 +5,7 @@ if [[ -z "$ELASTIC_USER" ]]; then
     export ELASTIC_USER=elastic
 fi
 
-ENV_VARS=("TA_USERNAME" "TA_PASSWORD" "ELASTIC_PASSWORD" "ELASTIC_USER")
-for each in "${ENV_VARS[@]}"; do
-    if ! [[ -v $each ]]; then
-        echo "missing environment variable $each"
-        exit 1
-    fi
-done
+: "${ELASTIC_PASSWORD:?"Missing required environment variable"}"
 
 # ugly nginx and uwsgi port overwrite with env vars
 if [[ -n "$TA_PORT" ]]; then
@@ -39,7 +33,9 @@ done
 # start python application
 python manage.py makemigrations
 python manage.py migrate
-export DJANGO_SUPERUSER_PASSWORD=$TA_PASSWORD && \
+
+[[ -n $TA_USERNAME && -v TA_PASSWORD ]] && \
+    export DJANGO_SUPERUSER_PASSWORD=$TA_PASSWORD && \
     python manage.py createsuperuser --noinput --name "$TA_USERNAME"
 
 python manage.py collectstatic --noinput -c


### PR DESCRIPTION
This prevents repeated runs of `createsuperuser` after the first successful one.  

* It uses a file to determine whether creation has already been run.
* Currently that file is `/cache/initsu.lock`, or `./initsu.lock` when outside Docker.
* If the file exists, it skips creation with a warning (and instructions to force it if that's what the user wants).
* If it *doesn't*, it's assumed to be a new install; creation happens as normal, file created on success.

---
#### Some notes
1. `ELASTIC_USER` is no longer required:
   * The original requirement had no effect anyway because of the 'elastic' default
2. Other variables will now error if they're set-but-empty:
   * They could previously be *empty*, as long as they were *set*
   * As an added bonus, this also fixes a fun accidental lockout scenario: you could *create* an account with no password, but it won't let you *log in* with one due to input validation on the login page.

**What this PR *does not* do:**
* *Account for existing installs where the default was removed/renamed*
  One final creation is inevitable, but could optionally be avoided with `touch cache/initsu.lock` before starting.
* *Enable any automatic creation after the first successful run* (...but that may be a feature in itself)  
  Shouldn't be needed, but steps to force re-creation are printed out to the log if someone *really* wants to

Fixes #261 