### PR TITLE
Fix permission/mount issues from #268

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,12 +54,11 @@ RUN if [ "$INSTALL_DEBUG" ] ; then \
     ; fi
 
 # make folders
-RUN mkdir /cache
-RUN mkdir /youtube
-RUN mkdir /app
+RUN mkdir /cache /youtube /app
 
 # copy config files
 COPY docker_assets/nginx.conf /etc/nginx/sites-available/default
+RUN sed -i 's/^user www\-data\;$/user root\;/' /etc/nginx/nginx.conf
 
 # copy application into container
 COPY ./tubearchivist /app

--- a/tubearchivist/home/src/download/yt_dlp_handler.py
+++ b/tubearchivist/home/src/download/yt_dlp_handler.py
@@ -398,7 +398,7 @@ class VideoDownloader:
         old_file_path = os.path.join(cache_dir, "download", old_file)
         new_file_path = os.path.join(videos, vid_dict["media_url"])
         # move media file and fix permission
-        shutil.move(old_file_path, new_file_path)
+        shutil.move(old_file_path, new_file_path, copy_function=shutil.copy)
         if host_uid and host_gid:
             os.chown(new_file_path, host_uid, host_gid)
 

--- a/tubearchivist/home/src/index/filesystem.py
+++ b/tubearchivist/home/src/index/filesystem.py
@@ -266,7 +266,7 @@ class ManualImport:
         if ext == ".mp4":
             new_file = video_file + ext
             dest_path = os.path.join(self.CACHE_DIR, "download", new_file)
-            shutil.move(video_path, dest_path)
+            shutil.move(video_path, dest_path, copy_function=shutil.copy)
         else:
             print(f"processing with ffmpeg: {video_file}")
             new_file = video_file + ".mp4"

--- a/tubearchivist/home/src/index/reindex.py
+++ b/tubearchivist/home/src/index/reindex.py
@@ -304,6 +304,6 @@ class ChannelUrlFixer:
         new_file_path = os.path.join(
             cache_dir, "download", self.youtube_id + ".mp4"
         )
-        shutil.move(video_path_is, new_file_path)
+        shutil.move(video_path_is, new_file_path, copy_function=shutil.copy)
         VideoDownloader().move_to_archive(self.video.json_data)
         self.video.update_media_url()


### PR DESCRIPTION
1. nginx is ran as root, the same as the main app and its services. This alleviates the issue in which nginx was unable to read the /youtube folder due to running as arbitrary user www-data unknown to the host. The Docker mounts, when using a host path, replicate directly the host permissions and owners UID and GID, which is why it wasn't working, resulting in an odd behavior from the user perspective, because downloading videos itself worked just fine.
I also took the liberty to change three `RUN` instructions that create dirs into just one for performance reasons, as every separate `RUN` directive causes a new layer to be created.

2. Changed
```py
shutil.move(old_file_path, new_file_path)
```
to
```
shutil.move(old_file_path, new_file_path, copy_function=shutil.copy)
```
as described on the issue page, as by default `shutil.copy2` fallback copy function is used, which tries to copy all the metadata and permissions from the source (/cache), which in this case is undesired and may (and does) lead to problems when the mounts are on different filesystems. Instead `shutil.copy` uses standard `cp` semantics, without trying to replicate the metadata after the copy.

I did keep the `os.chown` call below, as that seems to work just fine on the other hand, and is actually a useful functionality.

There are two more `shutil.move` calls across the whole codebase, but it is my understanding (might be wrong) that they operate only within the /cache dirs, and as such might be fine with no changes to them.

I tested these two changes on docker-compose setup on Debian and they seem to cause no side effects. You can reproduce the nginx problem by having a volume like `./youtube:/youtube` with permissions `700` on `./youtube`, owned by `root:root`.