### PR TITLE
Better description view for videos and playlists

### DIFF
--- a/tubearchivist/home/templates/home/channel_id_about.html
+++ b/tubearchivist/home/templates/home/channel_id_about.html
@@ -53,12 +53,10 @@
     </div>
     {% if channel_info.channel_description %}
         <div class="description-box">
-            <h2>Description</h2>
-        </div>
-        <div class="info-box-item description-box">
-            <div class="description-text">
-                {{ channel_info.channel_description|linebreaks }}
-            </div>
+            <p id="text-expand" class="description-text">
+                {{ channel_info.channel_description|linebreaksbr|urlizetrunc:50 }}
+            </p>
+            <button onclick="textExpand()" id="text-expand-button">Show more</button>
         </div>
     {% endif %}
     <div class="description-box">

--- a/tubearchivist/home/templates/home/playlist_id.html
+++ b/tubearchivist/home/templates/home/playlist_id.html
@@ -58,8 +58,8 @@
     {% if playlist_info.playlist_description %}
         <div class="info-box-item description-box">
             <p>Description: <button onclick="textReveal()" id="text-reveal-button">Show</button></p>
-            <div id="text-reveal" class="description-text">
-                {{ playlist_info.playlist_description|linebreaks }}
+            <div id="text-reveal" class="description-text" onload="textRevealButtonVisibilityUpdate()">
+                {{ playlist_info.playlist_description|linebreaksbr|urlizetrunc:50 }}
             </div>
         </div>
     {% endif %}

--- a/tubearchivist/home/templates/home/playlist_id.html
+++ b/tubearchivist/home/templates/home/playlist_id.html
@@ -56,11 +56,11 @@
         </div>
     </div>
     {% if playlist_info.playlist_description %}
-        <div class="info-box-item description-box">
-            <p>Description: <button onclick="textExpand()" id="text-expand-button">Show more</button></p>
+        <div class="description-box">
             <p id="text-expand" class="description-text">
                 {{ playlist_info.playlist_description|linebreaksbr|urlizetrunc:50 }}
             </p>
+            <button onclick="textExpand()" id="text-expand-button">Show more</button>
         </div>
     {% endif %}
 </div>

--- a/tubearchivist/home/templates/home/playlist_id.html
+++ b/tubearchivist/home/templates/home/playlist_id.html
@@ -57,10 +57,10 @@
     </div>
     {% if playlist_info.playlist_description %}
         <div class="info-box-item description-box">
-            <p>Description: <button onclick="textReveal()" id="text-reveal-button">Show</button></p>
-            <div id="text-reveal" class="description-text" onload="textRevealButtonVisibilityUpdate()">
+            <p>Description: <button onclick="textExpand()" id="text-expand-button">Show more</button></p>
+            <p id="text-expand" class="description-text">
                 {{ playlist_info.playlist_description|linebreaksbr|urlizetrunc:50 }}
-            </div>
+            </p>
         </div>
     {% endif %}
 </div>

--- a/tubearchivist/home/templates/home/video.html
+++ b/tubearchivist/home/templates/home/video.html
@@ -77,11 +77,11 @@
         </div>
     </div>
     {% if video.description %}
-        <div class="info-box-item description-box">
-            <p>Description: <button onclick="textExpand()" id="text-expand-button">Show more</button></p>
+        <div class="description-box">
             <p id="text-expand" class="description-text">
                 {{ video.description|linebreaksbr|urlizetrunc:50 }}
             </p>
+            <button onclick="textExpand()" id="text-expand-button">Show more</button>
         </div>
     {% endif %}
     {% if playlist_nav %}

--- a/tubearchivist/home/templates/home/video.html
+++ b/tubearchivist/home/templates/home/video.html
@@ -79,8 +79,8 @@
     {% if video.description %}
         <div class="info-box-item description-box">
             <p>Description: <button onclick="textReveal()" id="text-reveal-button">Show</button></p>
-            <div id="text-reveal" class="description-text">
-                {{ video.description|linebreaks }}
+            <div id="text-reveal" class="description-text" onload="textRevealButtonVisibilityUpdate()">
+                {{ video.description|linebreaksbr|urlizetrunc:50 }}
             </div>
         </div>
     {% endif %}

--- a/tubearchivist/home/templates/home/video.html
+++ b/tubearchivist/home/templates/home/video.html
@@ -78,10 +78,10 @@
     </div>
     {% if video.description %}
         <div class="info-box-item description-box">
-            <p>Description: <button onclick="textReveal()" id="text-reveal-button">Show</button></p>
-            <div id="text-reveal" class="description-text" onload="textRevealButtonVisibilityUpdate()">
+            <p>Description: <button onclick="textExpand()" id="text-expand-button">Show more</button></p>
+            <p id="text-expand" class="description-text">
                 {{ video.description|linebreaksbr|urlizetrunc:50 }}
-            </div>
+            </p>
         </div>
     {% endif %}
     {% if playlist_nav %}

--- a/tubearchivist/static/css/style.css
+++ b/tubearchivist/static/css/style.css
@@ -365,6 +365,11 @@ button:hover {
 }
 
 #text-reveal {
+    height: 0;
+    overflow: hidden;
+}
+
+#text-expand {
     overflow: hidden;
     display: -webkit-inline-box;
     -webkit-box-orient: vertical;

--- a/tubearchivist/static/css/style.css
+++ b/tubearchivist/static/css/style.css
@@ -598,6 +598,8 @@ button:hover {
 
 .description-box {
     margin-top: 1rem;
+    padding: 15px;
+    background-color: var(--highlight-bg);
 }
 
 .info-box-3 {

--- a/tubearchivist/static/css/style.css
+++ b/tubearchivist/static/css/style.css
@@ -365,8 +365,10 @@ button:hover {
 }
 
 #text-reveal {
-    height: 0px;
     overflow: hidden;
+    display: -webkit-inline-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
 }
 
 

--- a/tubearchivist/static/script.js
+++ b/tubearchivist/static/script.js
@@ -997,12 +997,12 @@ function textReveal() {
     var textBox = document.getElementById("text-reveal");
     var button = document.getElementById("text-reveal-button");
     var textBoxHeight = textBox.style.height;
-    if (textBoxHeight === 'unset') {
-        textBox.style.height = '0px';
-        button.innerText = 'Show';
+    if (textBoxHeight === "unset") {
+        textBox.style.height = "0px";
+        button.innerText = "Show";
     } else {
-        textBox.style.height = 'unset';
-        button.innerText = 'Hide';
+        textBox.style.height = "unset";
+        button.innerText = "Hide";
     }
 }
 
@@ -1040,7 +1040,7 @@ function textExpandButtonVisibilityUpdate() {
     }
 }
 
-window.addEventListener("load", textExpandButtonVisibilityUpdate);
+document.addEventListener("readystatechange", textExpandButtonVisibilityUpdate);
 window.addEventListener("resize", textExpandButtonVisibilityUpdate);
 
 function showForm() {

--- a/tubearchivist/static/script.js
+++ b/tubearchivist/static/script.js
@@ -994,35 +994,54 @@ function getCookie(c_name) {
 // animations
 
 function textReveal() {
-    var textBox = document.getElementById('text-reveal');
-    var button = document.getElementById('text-reveal-button');
-    var textBoxLineClamp = textBox.style["-webkit-line-clamp"];
-    if (textBoxLineClamp === 'none') {
-        textBox.style["-webkit-line-clamp"] = '4';
-        button.innerText = 'Show more';
+    var textBox = document.getElementById("text-reveal");
+    var button = document.getElementById("text-reveal-button");
+    var textBoxHeight = textBox.style.height;
+    if (textBoxHeight === 'unset') {
+        textBox.style.height = '0px';
+        button.innerText = 'Show';
     } else {
-        textBox.style["-webkit-line-clamp"] = 'none';
-        button.innerText = 'Show less';
+        textBox.style.height = 'unset';
+        button.innerText = 'Hide';
+    }
+}
+
+function textExpand() {
+    var textBox = document.getElementById("text-expand");
+    var button = document.getElementById("text-expand-button");
+    var textBoxLineClamp = textBox.style["-webkit-line-clamp"];
+    if (textBoxLineClamp === "none") {
+        textBox.style["-webkit-line-clamp"] = "4";
+        button.innerText = "Show more";
+    } else {
+        textBox.style["-webkit-line-clamp"] = "none";
+        button.innerText = "Show less";
     }
 }
 
 // hide "show more" button if all text is already visible
-function textRevealButtonVisibilityUpdate() {
-    var element = document.getElementById('text-reveal');
+function textExpandButtonVisibilityUpdate() {
+    var textBox = document.getElementById("text-expand");
+    var button = document.getElementById("text-expand-button");
+    if (!textBox || !button)
+        return;
 
-    var textBoxLineClamp = element.style["-webkit-line-clamp"];
-    if (textBoxLineClamp === 'none')
+    var textBoxLineClamp = textBox.style["-webkit-line-clamp"];
+    if (textBoxLineClamp === "none")
         return; // text box is in revealed state
 
-    if (element.offsetHeight < element.scrollHeight
-        || element.offsetWidth < element.scrollWidth) {
+    if (textBox.offsetHeight < textBox.scrollHeight
+        || textBox.offsetWidth < textBox.scrollWidth) {
         // the element has an overflow, show read more button
-        element.style.display = "block";
+        button.style.display = "inline-block";
     } else {
         // the element doesn't have overflow
-        element.style.display = "none";
+        button.style.display = "none";
     }
 }
+
+window.addEventListener("load", textExpandButtonVisibilityUpdate);
+window.addEventListener("resize", textExpandButtonVisibilityUpdate);
 
 function showForm() {
     var formElement = document.getElementById('hidden-form');

--- a/tubearchivist/static/script.js
+++ b/tubearchivist/static/script.js
@@ -967,6 +967,7 @@ function createPlaylist(playlist, viewStyle) {
 
 
 // generic
+
 function sendPost(payload) {
     var http = new XMLHttpRequest();
     http.open("POST", "/process/", true);
@@ -991,16 +992,35 @@ function getCookie(c_name) {
 
 
 // animations
+
 function textReveal() {
     var textBox = document.getElementById('text-reveal');
     var button = document.getElementById('text-reveal-button');
-    var textBoxHeight = textBox.style.height;
-    if (textBoxHeight === 'unset') {
-        textBox.style.height = '0px';
-        button.innerText = 'Show';
+    var textBoxLineClamp = textBox.style["-webkit-line-clamp"];
+    if (textBoxLineClamp === 'none') {
+        textBox.style["-webkit-line-clamp"] = '4';
+        button.innerText = 'Show more';
     } else {
-        textBox.style.height = 'unset';
-        button.innerText = 'Hide';
+        textBox.style["-webkit-line-clamp"] = 'none';
+        button.innerText = 'Show less';
+    }
+}
+
+// hide "show more" button if all text is already visible
+function textRevealButtonVisibilityUpdate() {
+    var element = document.getElementById('text-reveal');
+
+    var textBoxLineClamp = element.style["-webkit-line-clamp"];
+    if (textBoxLineClamp === 'none')
+        return; // text box is in revealed state
+
+    if (element.offsetHeight < element.scrollHeight
+        || element.offsetWidth < element.scrollWidth) {
+        // the element has an overflow, show read more button
+        element.style.display = "block";
+    } else {
+        // the element doesn't have overflow
+        element.style.display = "none";
     }
 }
 


### PR DESCRIPTION
Based on #269

I changed the template to `{{ video.description|linebreaksbr|urlizetrunc:50 }}`, `linebreaksbr` inserts only `<br>`s rather than `<p>` that didn't have appropriate spacings in the desc, also adds linkifying of URLs with truncation (YT truncates them at 38 for display, but that's clearly too low a value)

Now, `-webkit-line-clamp` may look very scary, but apparently it's a standardized feature that works everywhere but on Internet Explorer (including Firefox), and is pretty neat since it allows to easily insert the number of lines we want to clamp into without very fancy CSS or manual JS calculations, also adds ... at the end of last line to indicate there's more to show (I might try to move the button to display after the thing, but idk if it's possible)
See:
* https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp
* https://www.w3.org/TR/css-overflow-3/#propdef--webkit-line-clamp

Current issues with this draft PR:
* now the style rule from `p, i, li` isn't applied to div#text-reveal
* the default line clamp of 4 is hardcoded (it will need some changes to make it configurable, do we want it?)
* function textReveal() was changed, but also concealing API token in settings depends on it, and it should obviously not be partially shown by default, so these two display modes for div will probably need to be separated