### PR TITLE
Update settings.py

### DIFF
--- a/tubearchivist/config/settings.py
+++ b/tubearchivist/config/settings.py
@@ -31,6 +31,7 @@ SECRET_KEY = PW_HASH.hexdigest()
 DEBUG = bool(environ.get("DJANGO_DEBUG"))
 
 ALLOWED_HOSTS = [i.strip() for i in environ.get("TA_HOST").split()]
+CSRF_TRUSTED_ORIGINS = [i.strip() for i in environ.get("TA_HOST").split()]
 
 
 # Application definition


### PR DESCRIPTION
Certain reverse proxy settings were causing CSRF errors on login.

While the TA_HOST environment variable was putting the hosts into the Django ALLOWED_HOSTS setting this isn't enough for situations in which the reverse proxy server is offloading and SSL certificate. 
This causes situations where the Origin and Host can be the same URL but differ in their Schema.
For instance the __host__ is example.com, but the __origin__ is https://example.com.
Since they do not exactly match this causes a CSRF error.

This Pull requests adds the CSRF_TRUSTED_ORIGINS Django config settings and also sets it to the TA_HOST environment variable.
This fixes the login issues in these scenarios. This still locks down the requests to only the hosts specified by the user, but bypasses any issues caused by offloading an SSL certificate to a reverse proxy.