### PR TITLE
Add TA_LDAP_DISABLE_CERT_CHECK option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ You can configure LDAP with the following environment variables:
 
  - `TA_LDAP` (ex: `true`) Set to anything besides empty string to use LDAP authentication **instead** of local user authentication.
  - `TA_LDAP_SERVER_URI` (ex: `ldap://ldap-server:389`) Set to the uri of your LDAP server.
+ - `TA_LDAP_DISABLE_CERT_CHECK` (ex: `true`) Set to anything besides empty string to disable certificate checking when connecting over LDAPS.
  - `TA_LDAP_BIND_DN` (ex: `uid=search-user,ou=users,dc=your-server`) DN of the user that is able to perform searches on your LDAP account.
  - `TA_LDAP_BIND_PASSWORD` (ex: `yoursecretpassword`) Password for the search user.
  - `TA_LDAP_USER_BASE` (ex: `ou=users,dc=your-server`) Search base for user filter.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You can configure LDAP with the following environment variables:
 
  - `TA_LDAP` (ex: `true`) Set to anything besides empty string to use LDAP authentication **instead** of local user authentication.
  - `TA_LDAP_SERVER_URI` (ex: `ldap://ldap-server:389`) Set to the uri of your LDAP server.
- - `TA_LDAP_DISABLE_CERT_CHECK` (ex: `true`) Set to anything besides empty string to disable certificate checking when connecting over LDAPS.
+ - `TA_LDAP_DISABLE_CERT_CHECK` (ex: `true`) Set to anything besides empty string to disable certificate checking when connecting over LDAPS. (currently only in the unstable release, pending inclusion into stable)
  - `TA_LDAP_BIND_DN` (ex: `uid=search-user,ou=users,dc=your-server`) DN of the user that is able to perform searches on your LDAP account.
  - `TA_LDAP_BIND_PASSWORD` (ex: `yoursecretpassword`) Password for the search user.
  - `TA_LDAP_USER_BASE` (ex: `ou=users,dc=your-server`) Search base for user filter.

--- a/tubearchivist/config/settings.py
+++ b/tubearchivist/config/settings.py
@@ -119,6 +119,12 @@ if bool(environ.get("TA_LDAP")):
         "email": "mail",
     }
 
+    if bool(environ.get("TA_LDAP_DISABLE_CERT_CHECK")):
+        global AUTH_LDAP_GLOBAL_OPTIONS
+        AUTH_LDAP_GLOBAL_OPTIONS = {
+            ldap.OPT_X_TLS_REQUIRE_CERT: ldap.OPT_X_TLS_NEVER,
+        }
+
     global AUTHENTICATION_BACKENDS
     AUTHENTICATION_BACKENDS = ("django_auth_ldap.backend.LDAPBackend",)
 


### PR DESCRIPTION
Add a new environment variable to disable TLS certificate checking when connecting to LDAP servers using LDAPS.

Fixes #313 