### PR TITLE
add keyboard shortcuts to video player

### DIFF
--- a/tubearchivist/home/templates/home/video.html
+++ b/tubearchivist/home/templates/home/video.html
@@ -2,7 +2,9 @@
 {% block content %}
 {% load static %}
 {% load humanize %}
-<div class="video-main"></div>
+<div class="video-main">
+    <div class="video-modal"><span class="video-modal-text"></span></div>
+</div>
 <div class="notifications" id="notifications"></div>
 <div class="sponsorblock" id="sponsorblock">
     {% if video.sponsorblock.is_enabled %}
@@ -67,7 +69,7 @@
                     <p class="thumb-icon"><img class="dislike" src="{% static 'img/icon-thumb.svg' %}" alt="thumbs-down">: {{ video.stats.dislike_count|intcomma }}</p>
                 {% endif %}
                 {% if video.stats.average_rating %}
-                    <p class="rating-stars">Rating: 
+                    <p class="rating-stars">Rating:
                         {% for star in video.stats.average_rating %}
                             <img src="/static/img/icon-star-{{ star }}.svg" alt="{{ star }}">
                         {% endfor %}
@@ -90,7 +92,7 @@
                 <a href="{% url 'playlist_id' playlist_item.playlist_meta.playlist_id %}">
                     <h3>Playlist [{{ playlist_item.playlist_meta.current_idx|add:"1" }}]: {{ playlist_item.playlist_meta.playlist_name }}</h3>
                 </a>
-                <div class="playlist-nav">    
+                <div class="playlist-nav">
                     <div class="playlist-nav-item">
                         {% if playlist_item.playlist_previous %}
                             <a href="{% url 'video' playlist_item.playlist_previous.youtube_id %}">

--- a/tubearchivist/static/css/style.css
+++ b/tubearchivist/static/css/style.css
@@ -388,6 +388,7 @@ button:hover {
     display: grid;
     align-content: space-evenly;
     height: 100vh;
+    position: relative; /* needed for modal */
 }
 
 .notifications {

--- a/tubearchivist/static/css/style.css
+++ b/tubearchivist/static/css/style.css
@@ -744,6 +744,22 @@ video:-webkit-full-screen {
 /* video page */
 .video-main {
     margin: 1rem 0;
+    position: relative; /* needed for modal */
+}
+
+.video-modal {
+    position: absolute;
+    z-index: 1;
+    top: 20%;
+    width: 100%;
+    text-align: center;
+}
+
+.video-modal-text {
+    background: rgba(0,0,0,.5);
+    color: #eeeeee;
+    font-size: 1.3em;
+    display: none;
 }
 
 .video-main video {

--- a/tubearchivist/static/script.js
+++ b/tubearchivist/static/script.js
@@ -425,6 +425,7 @@ function createPlayer(button) {
 
     const markup = `
     <div class="video-player" data-id="${videoId}">
+        <div class="video-modal"><span class="video-modal-text"></span></div>
         ${videoTag}
         <div class="notifications" id="notifications"></div>
         ${sponsorBlockElements}
@@ -443,6 +444,7 @@ function createPlayer(button) {
     `;
     const divPlayer = document.getElementById("player");
     divPlayer.innerHTML = markup;
+    recordTextTrackChanges();
 }
 
 // Add video tag to video page when passed a video id, function loaded on page load `video.html (115-117)`
@@ -1180,6 +1182,9 @@ addEventListener('DOMContentLoaded', recordTextTrackChanges);
 let lastSeenTextTrack = 0;
 function recordTextTrackChanges() {
     let player = getVideoPlayer();
+    if (player == null) {
+        return;
+    }
     player.textTracks.addEventListener('change', () => {
         let active = [...player.textTracks].findIndex(x => x.mode === 'showing');
         if (active !== -1) {


### PR DESCRIPTION
Fixes https://github.com/tubearchivist/tubearchivist/issues/341.

Specifically, this adds:
- 'c' to toggle captions
- 'm' to toggle mute
- '>'/'<' to increase/decrease speed (by units of .25, up to 3x)
- left-arrow/right-arrow to skip around by 5 seconds
- space to toggle play/pause even if the video element isn't selected
- '?' to show shortcuts