### PR TITLE
Add LDAP attribute mapping env variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,12 @@ You can configure LDAP with the following environment variables:
  - `TA_LDAP_DISABLE_CERT_CHECK` (ex: `true`) Set to anything besides empty string to disable certificate checking when connecting over LDAPS.
  - `TA_LDAP_BIND_DN` (ex: `uid=search-user,ou=users,dc=your-server`) DN of the user that is able to perform searches on your LDAP account.
  - `TA_LDAP_BIND_PASSWORD` (ex: `yoursecretpassword`) Password for the search user.
+ - `TA_LDAP_USER_ATTR_MAP_USERNAME` (default: `uid`) Bind attribute used to map LDAP user's username
+ - `TA_LDAP_USER_ATTR_MAP_PERSONALNAME` (default: `givenName`) Bind attribute used to match LDAP user's First Name/Personal Name.
+ - `TA_LDAP_USER_ATTR_MAP_SURNAME` (default: `sn`) Bind attribute used to match LDAP user's Last Name/Surname.
+ - `TA_LDAP_USER_ATTR_MAP_EMAIL` (default: `mail`) Bind attribute used to match LDAP user's EMail address
  - `TA_LDAP_USER_BASE` (ex: `ou=users,dc=your-server`) Search base for user filter.
- - `TA_LDAP_USER_FILTER` (ex: `(objectClass=user)`) Filter for valid users. Login usernames are automatically matched using `uid` and does not need to be specified in this filter.
+ - `TA_LDAP_USER_FILTER` (ex: `(objectClass=user)`) Filter for valid users. Login usernames are matched using the attribute specified in `TA_LDAP_USER_ATTR_MAP_USERNAME` and should not be specified in this filter.
 
 When LDAP authentication is enabled, django passwords (e.g. the password defined in TA_PASSWORD), will not allow you to login, only the LDAP server is used.
 

--- a/tubearchivist/config/settings.py
+++ b/tubearchivist/config/settings.py
@@ -103,12 +103,11 @@ if bool(environ.get("TA_LDAP")):
     global AUTH_LDAP_BIND_PASSWORD
     AUTH_LDAP_BIND_PASSWORD = environ.get("TA_LDAP_BIND_PASSWORD")
 
-    
     """
-    Since these are new environment variables, taking the opporunity to use 
+    Since these are new environment variables, taking the opporunity to use
     more accurate env names.
     Given Names are *_technically_* different from Personal names, as people
-    who change their names have different given names and personal names, 
+    who change their names have different given names and personal names,
     and they go by personal names. Additionally, "LastName" is actually
     incorrect for many cultures, such as Korea, where the
     family name comes first, and the personal name comes last.
@@ -118,7 +117,7 @@ if bool(environ.get("TA_LDAP")):
     """
 
     # Attribute mapping options
-    
+
     global AUTH_LDAP_USER_ATTR_MAP_USERNAME
     AUTH_LDAP_USER_ATTR_MAP_USERNAME = (
         environ.get("TA_LDAP_USER_ATTR_MAP_USERNAME")

--- a/tubearchivist/config/settings.py
+++ b/tubearchivist/config/settings.py
@@ -103,20 +103,55 @@ if bool(environ.get("TA_LDAP")):
     global AUTH_LDAP_BIND_PASSWORD
     AUTH_LDAP_BIND_PASSWORD = environ.get("TA_LDAP_BIND_PASSWORD")
 
+    
+    # Bind options
+
+    # Since these are new environment variables, taking the opporunity to use more accurate 
+    # env names. 
+    # Given Names are *_technically_* different from Personal names, as people who change their names
+    # have different given names and personal names, and they go by personal names.
+    # Additionally, "LastName" is actually incorrect for many cultures, such as Korea, where the 
+    # family name comes first, and the personal name comes last. 
+    
+    # But we all know people are going to try to guess at these, so still want to include 
+    # names that people will guess, hence using first/last as well.
+
+    global AUTH_LDAP_BIND_ATTR_USERNAME
+    AUTH_LDAP_BIND_ATTR_USERNAME = environ.get("TA_LDAP_BIND_ATTR_USERNAME") or environ.get("TA_LDAP_BIND_ATTR_UID") or "uid",
+
+    global AUTH_LDAP_BIND_ATTR_PERSONALNAME
+    AUTH_LDAP_BIND_ATTR_PERSONALNAME = environ.get("TA_LDAP_BIND_ATTR_PERSONALNAME") or environ.get("TA_LDAP_BIND_ATTR_FIRSTNAME") or "givenName",
+
+    global AUTH_LDAP_BIND_ATTR_SURNAME 
+    AUTH_LDAP_BIND_ATTR_SURNAME = environ.get("TA_LDAP_BIND_ATTR_SURNAME") or environ.get("TA_LDAP_BIND_ATTR_LASTNAME") or "sn",
+
+    global AUTH_LDAP_BIND_ATTR_EMAIL
+    AUTH_LDAP_BIND_ATTR_EMAIL = environ.get("TA_LDAP_BIND_ATTR_EMAIL") or "mail",
+
+
+
+    global AUTH_LDAP_USER_BASE
+    AUTH_LDAP_USER_BASE = environ.get("TA_LDAP_USER_BASE")
+
+    global AUTH_LDAP_USER_FILTER
+    AUTH_LDAP_USER_FILTER = environ.get("TA_LDAP_USER_FILTER")
+
     global AUTH_LDAP_USER_SEARCH
     # pylint: disable=no-member
     AUTH_LDAP_USER_SEARCH = LDAPSearch(
-        environ.get("TA_LDAP_USER_BASE"),
+        AUTH_LDAP_USER_BASE,
         ldap.SCOPE_SUBTREE,
-        "(&(uid=%(user)s)" + environ.get("TA_LDAP_USER_FILTER") + ")",
+        "(&(%(AUTH_LDAP_BIND_ATTR_USERNAME)s=%(user)s)" + AUTH_LDAP_USER_FILTER + ")",
     )
+
+
 
     global AUTH_LDAP_USER_ATTR_MAP
     AUTH_LDAP_USER_ATTR_MAP = {
-        "username": "uid",
-        "first_name": "givenName",
-        "last_name": "sn",
-        "email": "mail",
+        "username": AUTH_LDAP_BIND_ATTR_USERNAME,
+        "first_name": AUTH_LDAP_BIND_ATTR_PERSONALNAME,
+        "last_name": AUTH_LDAP_BIND_ATTR_SURNAME,
+        "email": AUTH_LDAP_BIND_ATTR_EMAIL,
     }
 
     if bool(environ.get("TA_LDAP_DISABLE_CERT_CHECK")):

--- a/tubearchivist/config/settings.py
+++ b/tubearchivist/config/settings.py
@@ -104,7 +104,7 @@ if bool(environ.get("TA_LDAP")):
     AUTH_LDAP_BIND_PASSWORD = environ.get("TA_LDAP_BIND_PASSWORD")
 
     
-    # Bind options
+    # Attribute mapping options
 
     # Since these are new environment variables, taking the opporunity to use more accurate 
     # env names. 

--- a/tubearchivist/config/settings.py
+++ b/tubearchivist/config/settings.py
@@ -141,7 +141,11 @@ if bool(environ.get("TA_LDAP")):
     AUTH_LDAP_USER_SEARCH = LDAPSearch(
         AUTH_LDAP_USER_BASE,
         ldap.SCOPE_SUBTREE,
-        "(&("+AUTH_LDAP_USER_ATTR_MAP_USERNAME+"=%(user)s)" + AUTH_LDAP_USER_FILTER + ")",
+        "(&(" +
+        AUTH_LDAP_USER_ATTR_MAP_USERNAME +
+        "=%(user)s)" + 
+        AUTH_LDAP_USER_FILTER + 
+        ")",
     )
 
 

--- a/tubearchivist/config/settings.py
+++ b/tubearchivist/config/settings.py
@@ -117,16 +117,16 @@ if bool(environ.get("TA_LDAP")):
     # names that people will guess, hence using first/last as well.
 
     global AUTH_LDAP_USER_ATTR_MAP_USERNAME
-    AUTH_LDAP_USER_ATTR_MAP_USERNAME = environ.get("TA_LDAP_USER_ATTR_MAP_USERNAME") or environ.get("TA_LDAP_USER_ATTR_MAP_UID") or "uid",
+    AUTH_LDAP_USER_ATTR_MAP_USERNAME = environ.get("TA_LDAP_USER_ATTR_MAP_USERNAME") or environ.get("TA_LDAP_USER_ATTR_MAP_UID") or "uid"
 
     global AUTH_LDAP_USER_ATTR_MAP_PERSONALNAME
-    AUTH_LDAP_USER_ATTR_MAP_PERSONALNAME = environ.get("TA_LDAP_USER_ATTR_MAP_PERSONALNAME") or environ.get("TA_LDAP_USER_ATTR_MAP_FIRSTNAME") or "givenName",
+    AUTH_LDAP_USER_ATTR_MAP_PERSONALNAME = environ.get("TA_LDAP_USER_ATTR_MAP_PERSONALNAME") or environ.get("TA_LDAP_USER_ATTR_MAP_FIRSTNAME") or environ.get("TA_LDAP_USER_ATTR_MAP_GIVENNAME") or "givenName"
 
     global AUTH_LDAP_USER_ATTR_MAP_SURNAME 
-    AUTH_LDAP_USER_ATTR_MAP_SURNAME = environ.get("TA_LDAP_USER_ATTR_MAP_SURNAME") or environ.get("TA_LDAP_USER_ATTR_MAP_LASTNAME") or "sn",
+    AUTH_LDAP_USER_ATTR_MAP_SURNAME = environ.get("TA_LDAP_USER_ATTR_MAP_SURNAME") or environ.get("TA_LDAP_USER_ATTR_MAP_LASTNAME") or environ.get("TA_LDAP_USER_ATTR_MAP_FAMILYNAME") or "sn"
 
     global AUTH_LDAP_USER_ATTR_MAP_EMAIL
-    AUTH_LDAP_USER_ATTR_MAP_EMAIL = environ.get("TA_LDAP_USER_ATTR_MAP_EMAIL") or environ.get("TA_LDAP_USER_ATTR_MAP_MAIL") or "mail",
+    AUTH_LDAP_USER_ATTR_MAP_EMAIL = environ.get("TA_LDAP_USER_ATTR_MAP_EMAIL") or environ.get("TA_LDAP_USER_ATTR_MAP_MAIL") or "mail"
 
 
 
@@ -141,7 +141,7 @@ if bool(environ.get("TA_LDAP")):
     AUTH_LDAP_USER_SEARCH = LDAPSearch(
         AUTH_LDAP_USER_BASE,
         ldap.SCOPE_SUBTREE,
-        "(&(%(AUTH_LDAP_USER_ATTR_MAP_USERNAME)s=%(user)s)" + AUTH_LDAP_USER_FILTER + ")",
+        "(&("+AUTH_LDAP_USER_ATTR_MAP_USERNAME+"=%(user)s)" + AUTH_LDAP_USER_FILTER + ")",
     )
 
 

--- a/tubearchivist/config/settings.py
+++ b/tubearchivist/config/settings.py
@@ -103,18 +103,22 @@ if bool(environ.get("TA_LDAP")):
     global AUTH_LDAP_BIND_PASSWORD
     AUTH_LDAP_BIND_PASSWORD = environ.get("TA_LDAP_BIND_PASSWORD")
 
+    
+    """
+    Since these are new environment variables, taking the opporunity to use 
+    more accurate env names.
+    Given Names are *_technically_* different from Personal names, as people
+    who change their names have different given names and personal names, 
+    and they go by personal names. Additionally, "LastName" is actually
+    incorrect for many cultures, such as Korea, where the
+    family name comes first, and the personal name comes last.
+
+    But we all know people are going to try to guess at these, so still want
+    to include names that people will guess, hence using first/last as well.
+    """
+
     # Attribute mapping options
-
-    # Since these are new environment variables, taking the opporunity to use more accurate
-    # env names.
-    # Given Names are *_technically_* different from Personal names, as people who change their names
-    # have different given names and personal names, and they go by personal names.
-    # Additionally, "LastName" is actually incorrect for many cultures, such as Korea, where the
-    # family name comes first, and the personal name comes last.
-
-    # But we all know people are going to try to guess at these, so still want to include
-    # names that people will guess, hence using first/last as well.
-
+    
     global AUTH_LDAP_USER_ATTR_MAP_USERNAME
     AUTH_LDAP_USER_ATTR_MAP_USERNAME = (
         environ.get("TA_LDAP_USER_ATTR_MAP_USERNAME")

--- a/tubearchivist/config/settings.py
+++ b/tubearchivist/config/settings.py
@@ -103,32 +103,47 @@ if bool(environ.get("TA_LDAP")):
     global AUTH_LDAP_BIND_PASSWORD
     AUTH_LDAP_BIND_PASSWORD = environ.get("TA_LDAP_BIND_PASSWORD")
 
-    
     # Attribute mapping options
 
-    # Since these are new environment variables, taking the opporunity to use more accurate 
-    # env names. 
+    # Since these are new environment variables, taking the opporunity to use more accurate
+    # env names.
     # Given Names are *_technically_* different from Personal names, as people who change their names
     # have different given names and personal names, and they go by personal names.
-    # Additionally, "LastName" is actually incorrect for many cultures, such as Korea, where the 
-    # family name comes first, and the personal name comes last. 
-    
-    # But we all know people are going to try to guess at these, so still want to include 
+    # Additionally, "LastName" is actually incorrect for many cultures, such as Korea, where the
+    # family name comes first, and the personal name comes last.
+
+    # But we all know people are going to try to guess at these, so still want to include
     # names that people will guess, hence using first/last as well.
 
     global AUTH_LDAP_USER_ATTR_MAP_USERNAME
-    AUTH_LDAP_USER_ATTR_MAP_USERNAME = environ.get("TA_LDAP_USER_ATTR_MAP_USERNAME") or environ.get("TA_LDAP_USER_ATTR_MAP_UID") or "uid"
+    AUTH_LDAP_USER_ATTR_MAP_USERNAME = (
+        environ.get("TA_LDAP_USER_ATTR_MAP_USERNAME")
+        or environ.get("TA_LDAP_USER_ATTR_MAP_UID")
+        or "uid"
+    )
 
     global AUTH_LDAP_USER_ATTR_MAP_PERSONALNAME
-    AUTH_LDAP_USER_ATTR_MAP_PERSONALNAME = environ.get("TA_LDAP_USER_ATTR_MAP_PERSONALNAME") or environ.get("TA_LDAP_USER_ATTR_MAP_FIRSTNAME") or environ.get("TA_LDAP_USER_ATTR_MAP_GIVENNAME") or "givenName"
+    AUTH_LDAP_USER_ATTR_MAP_PERSONALNAME = (
+        environ.get("TA_LDAP_USER_ATTR_MAP_PERSONALNAME")
+        or environ.get("TA_LDAP_USER_ATTR_MAP_FIRSTNAME")
+        or environ.get("TA_LDAP_USER_ATTR_MAP_GIVENNAME")
+        or "givenName"
+    )
 
-    global AUTH_LDAP_USER_ATTR_MAP_SURNAME 
-    AUTH_LDAP_USER_ATTR_MAP_SURNAME = environ.get("TA_LDAP_USER_ATTR_MAP_SURNAME") or environ.get("TA_LDAP_USER_ATTR_MAP_LASTNAME") or environ.get("TA_LDAP_USER_ATTR_MAP_FAMILYNAME") or "sn"
+    global AUTH_LDAP_USER_ATTR_MAP_SURNAME
+    AUTH_LDAP_USER_ATTR_MAP_SURNAME = (
+        environ.get("TA_LDAP_USER_ATTR_MAP_SURNAME")
+        or environ.get("TA_LDAP_USER_ATTR_MAP_LASTNAME")
+        or environ.get("TA_LDAP_USER_ATTR_MAP_FAMILYNAME")
+        or "sn"
+    )
 
     global AUTH_LDAP_USER_ATTR_MAP_EMAIL
-    AUTH_LDAP_USER_ATTR_MAP_EMAIL = environ.get("TA_LDAP_USER_ATTR_MAP_EMAIL") or environ.get("TA_LDAP_USER_ATTR_MAP_MAIL") or "mail"
-
-
+    AUTH_LDAP_USER_ATTR_MAP_EMAIL = (
+        environ.get("TA_LDAP_USER_ATTR_MAP_EMAIL")
+        or environ.get("TA_LDAP_USER_ATTR_MAP_MAIL")
+        or "mail"
+    )
 
     global AUTH_LDAP_USER_BASE
     AUTH_LDAP_USER_BASE = environ.get("TA_LDAP_USER_BASE")
@@ -141,14 +156,12 @@ if bool(environ.get("TA_LDAP")):
     AUTH_LDAP_USER_SEARCH = LDAPSearch(
         AUTH_LDAP_USER_BASE,
         ldap.SCOPE_SUBTREE,
-        "(&(" +
-        AUTH_LDAP_USER_ATTR_MAP_USERNAME +
-        "=%(user)s)" + 
-        AUTH_LDAP_USER_FILTER + 
-        ")",
+        "(&("
+        + AUTH_LDAP_USER_ATTR_MAP_USERNAME
+        + "=%(user)s)"
+        + AUTH_LDAP_USER_FILTER
+        + ")",
     )
-
-
 
     global AUTH_LDAP_USER_ATTR_MAP
     AUTH_LDAP_USER_ATTR_MAP = {

--- a/tubearchivist/config/settings.py
+++ b/tubearchivist/config/settings.py
@@ -116,17 +116,17 @@ if bool(environ.get("TA_LDAP")):
     # But we all know people are going to try to guess at these, so still want to include 
     # names that people will guess, hence using first/last as well.
 
-    global AUTH_LDAP_BIND_ATTR_USERNAME
-    AUTH_LDAP_BIND_ATTR_USERNAME = environ.get("TA_LDAP_BIND_ATTR_USERNAME") or environ.get("TA_LDAP_BIND_ATTR_UID") or "uid",
+    global AUTH_LDAP_USER_ATTR_MAP_USERNAME
+    AUTH_LDAP_USER_ATTR_MAP_USERNAME = environ.get("TA_LDAP_USER_ATTR_MAP_USERNAME") or environ.get("TA_LDAP_USER_ATTR_MAP_UID") or "uid",
 
-    global AUTH_LDAP_BIND_ATTR_PERSONALNAME
-    AUTH_LDAP_BIND_ATTR_PERSONALNAME = environ.get("TA_LDAP_BIND_ATTR_PERSONALNAME") or environ.get("TA_LDAP_BIND_ATTR_FIRSTNAME") or "givenName",
+    global AUTH_LDAP_USER_ATTR_MAP_PERSONALNAME
+    AUTH_LDAP_USER_ATTR_MAP_PERSONALNAME = environ.get("TA_LDAP_USER_ATTR_MAP_PERSONALNAME") or environ.get("TA_LDAP_USER_ATTR_MAP_FIRSTNAME") or "givenName",
 
-    global AUTH_LDAP_BIND_ATTR_SURNAME 
-    AUTH_LDAP_BIND_ATTR_SURNAME = environ.get("TA_LDAP_BIND_ATTR_SURNAME") or environ.get("TA_LDAP_BIND_ATTR_LASTNAME") or "sn",
+    global AUTH_LDAP_USER_ATTR_MAP_SURNAME 
+    AUTH_LDAP_USER_ATTR_MAP_SURNAME = environ.get("TA_LDAP_USER_ATTR_MAP_SURNAME") or environ.get("TA_LDAP_USER_ATTR_MAP_LASTNAME") or "sn",
 
-    global AUTH_LDAP_BIND_ATTR_EMAIL
-    AUTH_LDAP_BIND_ATTR_EMAIL = environ.get("TA_LDAP_BIND_ATTR_EMAIL") or "mail",
+    global AUTH_LDAP_USER_ATTR_MAP_EMAIL
+    AUTH_LDAP_USER_ATTR_MAP_EMAIL = environ.get("TA_LDAP_USER_ATTR_MAP_EMAIL") or environ.get("TA_LDAP_USER_ATTR_MAP_MAIL") or "mail",
 
 
 
@@ -141,17 +141,17 @@ if bool(environ.get("TA_LDAP")):
     AUTH_LDAP_USER_SEARCH = LDAPSearch(
         AUTH_LDAP_USER_BASE,
         ldap.SCOPE_SUBTREE,
-        "(&(%(AUTH_LDAP_BIND_ATTR_USERNAME)s=%(user)s)" + AUTH_LDAP_USER_FILTER + ")",
+        "(&(%(AUTH_LDAP_USER_ATTR_MAP_USERNAME)s=%(user)s)" + AUTH_LDAP_USER_FILTER + ")",
     )
 
 
 
     global AUTH_LDAP_USER_ATTR_MAP
     AUTH_LDAP_USER_ATTR_MAP = {
-        "username": AUTH_LDAP_BIND_ATTR_USERNAME,
-        "first_name": AUTH_LDAP_BIND_ATTR_PERSONALNAME,
-        "last_name": AUTH_LDAP_BIND_ATTR_SURNAME,
-        "email": AUTH_LDAP_BIND_ATTR_EMAIL,
+        "username": AUTH_LDAP_USER_ATTR_MAP_USERNAME,
+        "first_name": AUTH_LDAP_USER_ATTR_MAP_PERSONALNAME,
+        "last_name": AUTH_LDAP_USER_ATTR_MAP_SURNAME,
+        "email": AUTH_LDAP_USER_ATTR_MAP_EMAIL,
     }
 
     if bool(environ.get("TA_LDAP_DISABLE_CERT_CHECK")):


### PR DESCRIPTION
When using a default Samba DC LDAP instance, `uid` isn't used to hold the username, so for this, and other LDAP implementations, it's necessary to be able to specify which LDAP attributes are actually used for first name, last name, username, email, etc.

This doesn't change the default behavior, as it uses the current hardcoded values as the default values instead of requiring admins to specify it if they are upgrading to a version containing this feature.