### PR TITLE
Make Dockerfile throw error instead of silently failing to install ffmpeg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ] ; then \
         rm ffmpeg.tar.xz \
     ; elif [ "$TARGETPLATFORM" = "linux/arm64" ] ; then \
         apt-get -y update && apt-get -y install --no-install-recommends ffmpeg && rm -rf /var/lib/apt/lists/* \
+    ; else \
+        >&2 echo "Specify TARGETPLATFORM as either linux/amd64 or linux/arm64." ; \
+        exit 1 \
     ; fi
 
 # install debug tools for testing environment


### PR DESCRIPTION
Creating an image with the Dockerfile will always complete, however when TARGETPLATFORM is null or a unexpected value, the resulting image does not include ffmpeg, causing containers to fail to actually download videos. 

This changes the behavior of the Dockerfile to fail on the ffmpeg installation step if TARGETPLATFORM is not `linux/amd64` or `linux/arm64`, as well as emitting a STDERR message and exiting with a 1, which stops the build on that step with that error message.