### PR TITLE
add github workflow to enforce linting of JS files

### DIFF
--- a/.github/workflows/lint_js.yml
+++ b/.github/workflows/lint_js.yml
@@ -1,0 +1,16 @@
+name: lint_js
+
+on: [pull_request, push]
+
+jobs:
+  check:
+    name: lint_js
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run format -- --check


### PR DESCRIPTION
Per https://github.com/tubearchivist/tubearchivist/pull/345#issuecomment-1291422057

I didn't fold this into the `deploy.sh validate` script because that would mean every contributor would need to have `node` installed, even if they weren't working on the JS parts at all.