### PR TITLE
Add podman installation instructions to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Once your YouTube video collection grows, it becomes hard to search and find a s
 - [Tube Archivist Metrics](https://github.com/tubearchivist/tubearchivist-metrics) to create statistics in Prometheus/OpenMetrics format.
 
 ## Installing and updating
-There's dedicated user-contributed install steps under [docs/Installation.md](./docs/Installation.md) for Unraid, Truenas and Synology which you can use instead of this section if you happen to be using one of those. Otherwise, continue on.
+There's dedicated user-contributed install steps under [docs/Installation.md](./docs/Installation.md) for podman, Unraid, Truenas and Synology which you can use instead of this section if you happen to be using one of those. Otherwise, continue on.
 
 For minimal system requirements, the Tube Archivist stack needs around 2GB of available memory for a small testing setup and around 4GB of available memory for a mid to large sized installation.  
 
@@ -81,8 +81,6 @@ Edit the following values from that file:
   - `TZ`: your time zone. If you don't know yours, you can look it up [here](https://www.timezoneconverter.com/cgi-bin/findzone/findzone).
 - under `archivist-es`->`environment`:
   - `"ELASTIC_PASSWORD=verysecret"`: change `verysecret` to match the ELASTIC_PASSWORD you picked above.
-
-**Note:** if you are using podman instead of docker, you will need to make some additional changes to that file, as listed in the [installation docs page](https://github.com/tubearchivist/tubearchivist/blob/master/docs/Installation.md).
 
 By default Docker will store all data, including downloaded data, in its own data-root directory (which you can find by running `docker info` and looking for the "Docker Root Dir"). If you want to use other locations, you can replace the `media:`, `cache:`, `redis:`, and `es:` volume names with absolute paths; if you do, remove them from the `volumes:` list at the bottom of the file.
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Edit the following values from that file:
 - under `archivist-es`->`environment`:
   - `"ELASTIC_PASSWORD=verysecret"`: change `verysecret` to match the ELASTIC_PASSWORD you picked above.
 
+**Note:** if you are using podman instead of docker, you will need to make some additional changes to that file, as listed in the [installation docs page](https://github.com/tubearchivist/tubearchivist/blob/master/docs/Installation.md).
+
 By default Docker will store all data, including downloaded data, in its own data-root directory (which you can find by running `docker info` and looking for the "Docker Root Dir"). If you want to use other locations, you can replace the `media:`, `cache:`, `redis:`, and `es:` volume names with absolute paths; if you do, remove them from the `volumes:` list at the bottom of the file.
 
 From a terminal, `cd` into the directory you saved the `docker-compose.yml` file in and run `docker compose up --detach`. The first time you do this it will download the appropriate images, which can take a minute.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,11 +1,39 @@
 # Detailed Installation Instructions for Various Platforms
 
 ## Table of Contents
+- [Podman](#podman)
 - [Unraid](#unraid)
 - [Truenas Scale](#truenas-scale)
 - [Synology](#synology)
 
 These are beginners guides installation instructions for additional platforms generously provided by users of these platforms. When in doubt, verify the details with the [Readme](https://github.com/tubearchivist/tubearchivist#installing-and-updating). If you see any issues here while using these instructions, please contribute. 
+
+## Podman
+Podman handles container hostname resolving slightly differently than docker, so you need to make a few changes to the `docker-compose.yml` to get up and running.
+
+### Step 1: Follow the installation instructions from the [README](https://github.com/tubearchivist/tubearchivist#installing-and-updating), with a few additional changes to the `docker-compose.yml`.
+
+Edit these additional changes to the `docker-compose.yml`:
+ - under `tubearchivist`->`image`:
+ 	- prefix the container name with `docker.io/` (or the url of your repo of choice).
+ - under `tubearchivist`->`environment`:
+  - `ES_URL`: change `archivist-es` to the internal IP of the computer that will be running the containers.
+  - `REDIS_HOST`: change `archivist-redis` to the internal IP of the computer that will be running the containers (should be the same as above).
+ - under `archivist-redis`->`image`: 
+ 	- prefix the container name with `docker.io/` again.
+ - under `archivist-redis`->`expose`: 
+  - change the whole entry from `expose: ["<PORT>"]` into `ports: ["<PORT>:<PORT>"].
+ - under `archivist-es`->`image`: 
+ 	- prefix the container name with `docker.io/` again.
+ - under `archivist-es`->`expose`: 
+  - change the whole entry from `expose: ["<PORT>"]` into `ports: ["<PORT>:<PORT>"].
+
+### Step 2: Create service files (optional)
+
+Since podman doesn't run as a service, it can't start containers after reboots, at least not without some help.
+
+If you want to enable this behavior, you can follow [this example](https://techblog.jeppson.org/2020/04/create-podman-services-with-podman-compose/) to have `systemd` start up the containers with `podman-compose` when the computer boots up.
+
 
 ## Unraid
 


### PR DESCRIPTION
As mentioned in the discord server, I've added some additional information required to run Tube Archivist with podman.

I've also added a notice that podman users should check out the `docs/Installtion.md` page to make the changes necessary to get it to work.

Potential feedback spots:
 - Service file creation: while not strictly necessary, it brings the experience on-par with docker. If you don't want to link out to an external website, I can either inline the resulting service file, change to link to an archived version of the page, or I can remove the section altogether
 - Resulting `docker-compose.yml`: I can inline the included compose file with the mentioned changes, if deemed necessary.