### PR TITLE
Add search usage summary on the search page and improve the search docs

### DIFF
--- a/docs/Search.md
+++ b/docs/Search.md
@@ -1,31 +1,32 @@
 # Search Page
 Accessible at `/search/` of your **Tube Archivist**, search your archive for Videos, Channels and Playlists - or even full text search throughout your indexed subtitles.
 
+Just start typing to start a **simple** search *or* **start your query with a primary keyword** to search for a specific type and narrow down the result with secondary keywords. Secondary keywords can be in any order. Use *yes* or *no* for boolean values.
+
+- This will return 30 results per query, pagination is not implemented yet.
 - All your queries are case insensitive and are normalized to lowercase.
 - All your queries are analyzed for the english language, this means *singular*, *plural* and word variations like *-ing*, *-ed*, *-able* etc are treated as synonyms.
+- Keyword value parsing begins with the `keyword:` name all the way until the end of query or the next keyword, e.g. in `video:learn python channel:corey`, the keyword `video` has value `learn python`.
 - Fuzzy search is activated for all your searches by default. This can catch typos in your queries or in the matching documents with one to two letters difference, depending on the query length. You can configure fuzziness with the secondary keyword `fuzzy:`, e.g:
   - `fuzzy:0` or `fuzzy:no`: Deactivate fuzzy matching.
   - `fuzzy:1`: Set fuzziness to one letter difference.
   - `fuzzy:2`: Set fuzziness to two letters difference.
 - All text searches are ranked, meaning the better a match the higher ranked the result. Unless otherwise stated, queries with multiple words are processed with the `and` operator, meaning all words need to match so each word will narrow down the result.
-- This will return 30 results per query, pagination is not implemented yet.
-
-Just start typing to start a *simple* search or start your query with a primary keyword to search for a specific type and narrow down the result with secondary keywords. Secondary keywords can be in any order. Use *yes* or *no* for boolean values.
 
 ## Simple
-Start your query without a keyword to make a simple query. This will search in *video titles*, *channel names* and *playlist titles* and will return matching videos, channels and playlists. Keyword searches will return more results in a particular category due to the fact that more fields are searched for matches.
+Start your query without a keyword to make a simple query (primary keyword `simple:` is implied). This will search in *video titles*, *channel names* and *playlist titles* and will return matching videos, channels and playlists. Keyword searches will return more results in a particular category due to the fact that more fields are searched for matches. Simple queries do not have any secondary keywords.
 
 ## Video
-Start your query with the primary keyword `video:` to search for videos only. This will search through the *video titles*, *tags* and *category* fields. Narrow your search down with secondary keywords:
+Start your query with the **primary keyword** `video:` to search for videos only. This will search through the *video titles*, *tags* and *category* fields. Narrow your search down with secondary keywords:
 - `channel:` search for videos matching the channel name.
 - `active:` is a boolean value, to search for videos that are still active on youtube or that are not active any more.
 
 **Example**:
-- `video:learn python channel:corey shafer active:yes`: This will return all videos with the term *Learn Python* from the channel *Corey Shafer* that are still *Active* on YouTube.
+- `video:learn python channel:corey schafer active:yes`: This will return all videos with the term *Learn Python* from the channel *Corey Schafer* that are still *Active* on YouTube.
 - `video: channel:tom scott active:no`: Note the omitted term after the primary key, this will show all videos from the channel *Tom Scott* that are no longer active on YouTube.
 
 ## Channel
-Start with the `channel:` primary keyword to search for channels matching your query. This will search through the *channel name* and *channel description* fields. Narrow your search down with secondary keywords:
+Start with the `channel:` **primary keyword** to search for channels matching your query. This will search through the *channel name* and *channel description* fields. Narrow your search down with secondary keywords:
 - `subscribed:` is a boolean value, search for channels that you are subscribed to or not.
 - `active:` is a boolean value, to search for channels that are still active on YouTube or that are no longer active.
 
@@ -34,7 +35,7 @@ Start with the `channel:` primary keyword to search for channels matching your q
 - `channel: active:no`: Note the omitted term after the primary key, this will return all channels that are no longer active on YouTube.
 
 ## Playlist
-Start your query with the primary keyword `playlist:` to search for playlists only. This will search through the *playlist title* and *playlist description* fields. Narrow down your search with these secondary keywords:
+Start your query with the **primary keyword** `playlist:` to search for playlists only. This will search through the *playlist title* and *playlist description* fields. Narrow down your search with these secondary keywords:
 - `subscribed`: is a boolean value, search for playlists that you are subscribed to or not.
 - `active:` is a boolean value, to search for playlists that are still active on YouTube or that are no longer active.
 
@@ -44,7 +45,7 @@ Start your query with the primary keyword `playlist:` to search for playlists on
 - `playlist:html css active:yes`: Search for playlists containing *HTML CSS* that are still active on YouTube.
 
 ## Full
-Start a full text search by beginning your query with the primary keyword `full:`. This will search through your indexed Subtitles showing segments with possible matches. This will only show any results if you have activated *subtitle download and index* on the settings page. The operator for full text searches is `or` meaning when searching for multiple words not all words need to match, but additional words will change the ranking of the result, the more words match and the better they match, the higher ranked the result. The matching words will get highlighted in the text preview.
+Start a full text search by beginning your query with the **primary keyword** `full:`. This will search through your indexed Subtitles showing segments with possible matches. This will only show any results if you have activated *subtitle download and index* on the settings page. The operator for full text searches is `or` meaning when searching for multiple words not all words need to match, but additional words will change the ranking of the result, the more words match and the better they match, the higher ranked the result. The matching words will get highlighted in the text preview.
 
 Clicking the play button on the thumbnail will open the inplace player at the timestamp from where the segment starts. Same when clicking the video title, this will open the video page and put the player at the segment timestamp. This will overwrite any previous playback position.
 

--- a/tubearchivist/home/templates/home/search.html
+++ b/tubearchivist/home/templates/home/search.html
@@ -7,30 +7,80 @@
     </div>
     <div class="multi-search-box">
         {{ search_form }}
-        <p>Start typing or use <span class="settings-current">video:</span>, <span class="settings-current">channel:</span>, <span class="settings-current">playlist:</span> or <span class="settings-current">full:</span> keywords for advanced queries. <a href="https://github.com/tubearchivist/tubearchivist/wiki/Search" target="_blank">Learn more</a>.</p>
     </div>
-    <div class="multi-search-result">
-        <h2>Video Results</h2>
-        <div id="video-results" class="video-list {{ all_styles.home }} {% if all_styles.home == "grid" %}grid-{{ grid_items }}{% endif %}">
-            <p>No videos found.</p>
+    <div class="multi-search-results" style="display: none;">
+        <div class="multi-search-result">
+            <h2>Video Results</h2>
+            <div id="video-results" class="video-list {{ all_styles.home }} {% if all_styles.home == "grid" %}grid-{{ grid_items }}{% endif %}">
+                <p>No videos found.</p>
+            </div>
+        </div>
+        <div class="multi-search-result">
+            <h2>Channel Results</h2>
+            <div id="channel-results" class="channel-list {{ all_styles.channel }}">
+                <p>No channels found.</p>
+            </div>
+        </div>
+        <div class="multi-search-result">
+            <h2>Playlist Results</h2>
+            <div id="playlist-results" class="playlist-list {{ all_styles.playlist }}">
+                <p>No playlists found.</p>
+            </div>
+        </div>
+        <div class="multi-search-result">
+            <h2>Fulltext Results</h2>
+            <div id="fulltext-results" class="video-list list">
+                <p>No fulltext results found.</p>
+            </div>
         </div>
     </div>
-    <div class="multi-search-result">
-        <h2>Channel Results</h2>
-        <div id="channel-results" class="channel-list {{ all_styles.channel }}">
-            <p>No channels found.</p>
+    <div class="multi-search-results-placeholder" style="display: block;">
+        <div>
+            <h2>Example queries</h2>
+            <ul>
+                <li><tt class="value">gangam style</tt> — basic search</li>
+                <li><tt>video: active:</tt><tt class="value">no</tt> — all videos deleted from YouTube</li>
+                <li><tt>video:</tt><tt class="value">learn javascript</tt><tt> channel:</tt><tt class="value">corey schafer</tt><tt> active:</tt><tt class="value">yes</tt></li>
+                <li><tt>channel:</tt><tt class="value">linux</tt><tt> subscribed:</tt><tt class="value">yes</tt></li>
+                <li><tt>playlist:</tt><tt class="value">backend engineering</tt><tt> active:</tt><tt class="value">yes</tt><tt> subscribed:</tt><tt class="value">yes</tt></li>
+            </ul>
         </div>
-    </div>
-    <div class="multi-search-result">
-        <h2>Playlist Results</h2>
-        <div id="playlist-results" class="playlist-list {{ all_styles.playlist }}">
-            <p>No playlists found.</p>
-        </div>
-    </div>
-    <div class="multi-search-result">
-        <h2>Fulltext Results</h2>
-        <div id="fulltext-results" class="video-list list">
-            <p>No fulltext results found.</p>
+        <div>
+            <h2>Keywords cheatsheet</h2>
+            <p>For detailed usage check <a href="https://github.com/tubearchivist/tubearchivist/wiki/Search" target="_blank">wiki</a>.</p>
+            <div>
+                <ul>
+                    <li><tt>simple:</tt> (implied) — search in video titles, channel names and playlist titles</li>
+                    <li>
+                        <tt>video:</tt> — search in video titles, tags and category field
+                        <ul>
+                            <li><tt>channel:</tt> — channel name</li>
+                            <li><tt>active:</tt><tt class="value">yes/no</tt> — whether the video is still active on YouTube</li>
+                        </ul>
+                    </li>
+                    <li>
+                        <tt>channel:</tt> — search in channel name and channel description
+                        <ul>
+                            <li><tt>subscribed:</tt><tt class="value">yes/no</tt> — whether you are subscribed to the channel</li>
+                            <li><tt>active:</tt><tt class="value">yes/no</tt> — whether the video is still active on YouTube</li>
+                        </ul>
+                    </li>
+                    <li>
+                        <tt>playlist:</tt> — search in channel name and channel description
+                        <ul>
+                            <li><tt>subscribed:</tt><tt class="value">yes/no</tt> — whether you are subscribed to the channel</li>
+                            <li><tt>active:</tt><tt class="value">yes/no</tt> — whether the video is still active on YouTube</li>
+                        </ul>
+                    </li>
+                    <li>
+                        <tt>full:</tt> — search in video subtitles
+                        <ul>
+                            <li><tt>lang:</tt> — subtitles language (use two-letter ISO country code, same as the one from settings page)</li>
+                            <li><tt>source:</tt><tt class="value">auto/user</tt> — <i>auto</i> to search though auto-generated subtitles only, or <i>user</i> to search through user-uploaded subtitles only</li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
         </div>
     </div>
 </div>

--- a/tubearchivist/home/templates/home/search.html
+++ b/tubearchivist/home/templates/home/search.html
@@ -8,7 +8,7 @@
     <div class="multi-search-box">
         {{ search_form }}
     </div>
-    <div class="multi-search-results" style="display: none;">
+    <div id="multi-search-results" style="display: none;">
         <div class="multi-search-result">
             <h2>Video Results</h2>
             <div id="video-results" class="video-list {{ all_styles.home }} {% if all_styles.home == "grid" %}grid-{{ grid_items }}{% endif %}">
@@ -34,7 +34,7 @@
             </div>
         </div>
     </div>
-    <div class="multi-search-results-placeholder" style="display: block;">
+    <div id="multi-search-results-placeholder" style="display: block;">
         <div>
             <h2>Example queries</h2>
             <ul>

--- a/tubearchivist/home/templates/home/search.html
+++ b/tubearchivist/home/templates/home/search.html
@@ -38,11 +38,11 @@
         <div>
             <h2>Example queries</h2>
             <ul>
-                <li><tt class="value">gangam style</tt> — basic search</li>
-                <li><tt>video: active:</tt><tt class="value">no</tt> — all videos deleted from YouTube</li>
-                <li><tt>video:</tt><tt class="value">learn javascript</tt><tt> channel:</tt><tt class="value">corey schafer</tt><tt> active:</tt><tt class="value">yes</tt></li>
-                <li><tt>channel:</tt><tt class="value">linux</tt><tt> subscribed:</tt><tt class="value">yes</tt></li>
-                <li><tt>playlist:</tt><tt class="value">backend engineering</tt><tt> active:</tt><tt class="value">yes</tt><tt> subscribed:</tt><tt class="value">yes</tt></li>
+                <li><span class="value">music video</span> — basic search</li>
+                <li><span>video: active:</span><span class="value">no</span> — all videos deleted from YouTube</li>
+                <li><span>video:</span><span class="value">learn javascript</span><span> channel:</span><span class="value">corey schafer</span><span> active:</span><span class="value">yes</span></li>
+                <li><span>channel:</span><span class="value">linux</span><span> subscribed:</span><span class="value">yes</span></li>
+                <li><span>playlist:</span><span class="value">backend engineering</span><span> active:</span><span class="value">yes</span><span> subscribed:</span><span class="value">yes</span></li>
             </ul>
         </div>
         <div>
@@ -50,33 +50,33 @@
             <p>For detailed usage check <a href="https://github.com/tubearchivist/tubearchivist/wiki/Search" target="_blank">wiki</a>.</p>
             <div>
                 <ul>
-                    <li><tt>simple:</tt> (implied) — search in video titles, channel names and playlist titles</li>
+                    <li><span>simple:</span> (implied) — search in video titles, channel names and playlist titles</li>
                     <li>
-                        <tt>video:</tt> — search in video titles, tags and category field
+                        <span>video:</span> — search in video titles, tags and category field
                         <ul>
-                            <li><tt>channel:</tt> — channel name</li>
-                            <li><tt>active:</tt><tt class="value">yes/no</tt> — whether the video is still active on YouTube</li>
+                            <li><span>channel:</span> — channel name</li>
+                            <li><span>active:</span><span class="value">yes/no</span> — whether the video is still active on YouTube</li>
                         </ul>
                     </li>
                     <li>
-                        <tt>channel:</tt> — search in channel name and channel description
+                        <span>channel:</span> — search in channel name and channel description
                         <ul>
-                            <li><tt>subscribed:</tt><tt class="value">yes/no</tt> — whether you are subscribed to the channel</li>
-                            <li><tt>active:</tt><tt class="value">yes/no</tt> — whether the video is still active on YouTube</li>
+                            <li><span>subscribed:</span><span class="value">yes/no</span> — whether you are subscribed to the channel</li>
+                            <li><span>active:</span><span class="value">yes/no</span> — whether the video is still active on YouTube</li>
                         </ul>
                     </li>
                     <li>
-                        <tt>playlist:</tt> — search in channel name and channel description
+                        <span>playlist:</span> — search in channel name and channel description
                         <ul>
-                            <li><tt>subscribed:</tt><tt class="value">yes/no</tt> — whether you are subscribed to the channel</li>
-                            <li><tt>active:</tt><tt class="value">yes/no</tt> — whether the video is still active on YouTube</li>
+                            <li><span>subscribed:</span><span class="value">yes/no</span> — whether you are subscribed to the channel</li>
+                            <li><span>active:</span><span class="value">yes/no</span> — whether the video is still active on YouTube</li>
                         </ul>
                     </li>
                     <li>
-                        <tt>full:</tt> — search in video subtitles
+                        <span>full:</span> — search in video subtitles
                         <ul>
-                            <li><tt>lang:</tt> — subtitles language (use two-letter ISO country code, same as the one from settings page)</li>
-                            <li><tt>source:</tt><tt class="value">auto/user</tt> — <i>auto</i> to search though auto-generated subtitles only, or <i>user</i> to search through user-uploaded subtitles only</li>
+                            <li><span>lang:</span> — subtitles language (use two-letter ISO country code, same as the one from settings page)</li>
+                            <li><span>source:</span><span class="value">auto/user</span> — <i>auto</i> to search though auto-generated subtitles only, or <i>user</i> to search through user-uploaded subtitles only</li>
                         </ul>
                     </li>
                 </ul>

--- a/tubearchivist/static/css/style.css
+++ b/tubearchivist/static/css/style.css
@@ -892,8 +892,16 @@ video:-webkit-full-screen {
     width: 100%;
 }
 
-.multi-search-result {
+.multi-search-result, .multi-search-results-placeholder {
     padding: 1rem 0;
+}
+
+.multi-search-results tt {
+    background-color: lightblue;
+}
+
+.multi-search-results tt.value {
+    background-color: lightsteelblue;
 }
 
 /* channel overview page */

--- a/tubearchivist/static/css/style.css
+++ b/tubearchivist/static/css/style.css
@@ -892,15 +892,15 @@ video:-webkit-full-screen {
     width: 100%;
 }
 
-.multi-search-result, .multi-search-results-placeholder {
+.multi-search-result, #multi-search-results-placeholder {
     padding: 1rem 0;
 }
 
-.multi-search-results tt {
+#multi-search-results tt {
     background-color: lightblue;
 }
 
-.multi-search-results tt.value {
+#multi-search-results tt.value {
     background-color: lightsteelblue;
 }
 

--- a/tubearchivist/static/css/style.css
+++ b/tubearchivist/static/css/style.css
@@ -896,12 +896,17 @@ video:-webkit-full-screen {
     padding: 1rem 0;
 }
 
-#multi-search-results tt {
-    background-color: lightblue;
+#multi-search-results-placeholder span {
+    font-family: monospace;
+    background-color: var(--accent-font-dark);
 }
 
-#multi-search-results tt.value {
-    background-color: lightsteelblue;
+#multi-search-results-placeholder span.value {
+    background-color: var(--accent-font-light);
+}
+
+#multi-search-results-placeholder ul {
+    margin-top: 10px;
 }
 
 /* channel overview page */

--- a/tubearchivist/static/css/style.css
+++ b/tubearchivist/static/css/style.css
@@ -898,11 +898,12 @@ video:-webkit-full-screen {
 
 #multi-search-results-placeholder span {
     font-family: monospace;
-    background-color: var(--accent-font-dark);
+    color: var(--accent-font-dark);
+    background-color: var(--highlight-bg);
 }
 
 #multi-search-results-placeholder span.value {
-    background-color: var(--accent-font-light);
+    color: var(--accent-font-light);
 }
 
 #multi-search-results-placeholder ul {

--- a/tubearchivist/static/script.js
+++ b/tubearchivist/static/script.js
@@ -865,21 +865,34 @@ function setProgressBar(videoId, currentTime, duration) {
 
 // multi search form
 let searchTimeout = null;
+let searchHttpRequest = null;
 function searchMulti(query) {
   clearTimeout(searchTimeout);
   searchTimeout = setTimeout(function () {
-    if (query.length > 1) {
-      let http = new XMLHttpRequest();
-      http.onreadystatechange = function () {
-        if (http.readyState === 4) {
-          let response = JSON.parse(http.response);
+    if (query.length > 0) {
+      if (searchHttpRequest)
+        searchHttpRequest.abort();
+      searchHttpRequest = new XMLHttpRequest();
+      searchHttpRequest.onreadystatechange = function () {
+        if (searchHttpRequest.readyState === 4) {
+          const response = JSON.parse(searchHttpRequest.response);
           populateMultiSearchResults(response.results, response.queryType);
         }
       };
-      http.open('GET', `/api/search/?query=${query}`, true);
-      http.setRequestHeader('X-CSRFToken', getCookie('csrftoken'));
-      http.setRequestHeader('Content-type', 'application/json');
-      http.send();
+      searchHttpRequest.open('GET', `/api/search/?query=${query}`, true);
+      searchHttpRequest.setRequestHeader('X-CSRFToken', getCookie('csrftoken'));
+      searchHttpRequest.setRequestHeader('Content-type', 'application/json');
+      searchHttpRequest.send();
+    } else {
+      if (searchHttpRequest) {
+        searchHttpRequest.abort();
+        searchHttpRequest = null;
+      }
+      // show the placeholder container and hide the results container
+      for (const element of document.getElementsByClassName('multi-search-results'))
+        element.style.display = 'none';
+      for (const element of document.getElementsByClassName('multi-search-results-placeholder'))
+        element.style.display = 'block';
     }
   }, 500);
 }
@@ -890,6 +903,11 @@ function getViewDefaults(view) {
 }
 
 function populateMultiSearchResults(allResults, queryType) {
+  // show the results container and hide the placeholder container
+  for (const element of document.getElementsByClassName('multi-search-results'))
+    element.style.display = 'block';
+  for (const element of document.getElementsByClassName('multi-search-results-placeholder'))
+    element.style.display = 'none';
   // videos
   let defaultVideo = getViewDefaults('home');
   let allVideos = allResults.video_results;

--- a/tubearchivist/static/script.js
+++ b/tubearchivist/static/script.js
@@ -870,8 +870,9 @@ function searchMulti(query) {
   clearTimeout(searchTimeout);
   searchTimeout = setTimeout(function () {
     if (query.length > 0) {
-      if (searchHttpRequest)
+      if (searchHttpRequest) {
         searchHttpRequest.abort();
+      }
       searchHttpRequest = new XMLHttpRequest();
       searchHttpRequest.onreadystatechange = function () {
         if (searchHttpRequest.readyState === 4) {
@@ -889,10 +890,8 @@ function searchMulti(query) {
         searchHttpRequest = null;
       }
       // show the placeholder container and hide the results container
-      for (const element of document.getElementsByClassName('multi-search-results'))
-        element.style.display = 'none';
-      for (const element of document.getElementsByClassName('multi-search-results-placeholder'))
-        element.style.display = 'block';
+      document.getElementById('multi-search-results').style.display = 'none';
+      document.getElementById('multi-search-results-placeholder').style.display = 'block';
     }
   }, 500);
 }
@@ -904,10 +903,8 @@ function getViewDefaults(view) {
 
 function populateMultiSearchResults(allResults, queryType) {
   // show the results container and hide the placeholder container
-  for (const element of document.getElementsByClassName('multi-search-results'))
-    element.style.display = 'block';
-  for (const element of document.getElementsByClassName('multi-search-results-placeholder'))
-    element.style.display = 'none';
+  document.getElementById('multi-search-results').style.display = 'block';
+  document.getElementById('multi-search-results-placeholder').style.display = 'none';
   // videos
   let defaultVideo = getViewDefaults('home');
   let allVideos = allResults.video_results;


### PR DESCRIPTION
When search query is empty, it adds this page which summaries the basic search (along with some examples), so that the user can quickly grasp/look up how search is performed without reading up the wiki:
![image](https://user-images.githubusercontent.com/5182588/217538054-fb7054eb-b9a0-4d27-8c11-593be1cbff52.png)

The docs are improved a tad too to *hopefully* make it more clear how search keywords work to the reader.