### PR TITLE
Refresh progress on downloads page more often (3000 ms => 500 ms)

### DIFF
--- a/tubearchivist/static/progress.js
+++ b/tubearchivist/static/progress.js
@@ -28,16 +28,12 @@ function checkMessages() {
 // get messages for page on timer
 function getMessages(dataOrigin) {
   fetch('/progress/')
-    .then(response => {
-      return response.json();
-    })
+    .then(response => response.json())
     .then(responseData => {
-      let messages = buildMessage(responseData, dataOrigin);
+      const messages = buildMessage(responseData, dataOrigin);
       if (messages.length > 0) {
         // restart itself
-        setTimeout(function () {
-          getMessages(dataOrigin);
-        }, 3000);
+        setTimeout(() => getMessages(dataOrigin), 500);
       }
     });
 }


### PR DESCRIPTION
I believe it makes sense to do that, because 3 seconds is quite a slow rate. And most people sitting on Downloads screen, I assume, are watching as their downloads are getting done, and could appreciate snappier refresh of the progress. I think 500 ms is still a rather conservative time, and should not pose increased strain on the server, given it just makes a few redis get queries to grab it. In any case, even if network or server is overloaded, the requests are only issued 500 ms *after* previous response is received, and not just on constant interval irregardless of whether previous response arrived.

With all the above considered, I think the (negligible) const of refreshing the progress text a bit often is worth it for the sake of nicer/snappier/more up-to-date progress display, especially that the requests only keep getting issued while any videos are being downloaded and stop once progress becomes empty.

[ Of course for the snappiest experience it would be ideal to implement a websocket endpoint which could push progress as it happens, but that would require substantially more work to code and ensure it works properly... (Redis has its keyspace notifications that could potentially suit there, but not sure if the Python framework in use even supports websocket endpoints in the first place + also reverse proxies would need to support it fine or we'd need to have a fallback). Alternatively server-sent events could be considered, and perhaps that would be way easier than websockets. ]