### PR TITLE
Fix video skipping 1% instead of 5s

### DIFF
--- a/tubearchivist/static/script.js
+++ b/tubearchivist/static/script.js
@@ -1458,19 +1458,11 @@ function doShortcut(e) {
       break;
     }
     case 'ArrowLeft': {
-      if (targetName === 'video') {
-        // hitting arrows while the video is focused will use the built-in skip
-        break;
-      }
       showModal('- 5 seconds', 500);
       player.currentTime -= 5;
       break;
     }
     case 'ArrowRight': {
-      if (targetName === 'video') {
-        // hitting space while the video is focused will use the built-in skip
-        break;
-      }
       showModal('+ 5 seconds', 500);
       player.currentTime += 5;
       break;


### PR DESCRIPTION
When the video is focused, the built-in behavior is to skip 1% of the video instead of 5s, which isn't good.