### PR TITLE
Accept members-only/paid-content playlist IDs/URLs

### DIFF
--- a/tubearchivist/home/src/ta/urlparser.py
+++ b/tubearchivist/home/src/ta/urlparser.py
@@ -92,7 +92,7 @@ class Parser:
             item_type = "video"
         elif len_id_str == 24:
             item_type = "channel"
-        elif len_id_str in (34, 18):
+        elif len_id_str in (34, 26, 18):
             item_type = "playlist"
         else:
             raise ValueError(f"not a valid id_str: {id_str}")


### PR DESCRIPTION
This adds a new check to the playlist url_id check to allow playlist urls from subscription/members only content on Youtube channels.

The channel I tested on had an ID length of 26 (https://www.youtube.com/playlist?list=UUMOvk0KB4Ue0vfPqvDzjIAwiQ), I am not sure if other lengths are valid here. 

I have tested this on my local install and it's downloading the members only playlist correctly as long as I have valid youtube cookies.

I am also willing to update the documentation to describe the process for adding in members-only playlists if this is otherwise an accepted feature.

Related Issue: https://github.com/tubearchivist/tubearchivist/issues/470