### PR TITLE
Allow to configure yt-dlp `--format-sort` argument

### DIFF
--- a/tubearchivist/home/config.json
+++ b/tubearchivist/home/config.json
@@ -24,6 +24,7 @@
         "sleep_interval": 3,
         "autodelete_days": false,
         "format": false,
+        "format_sort": false,
         "add_metadata": false,
         "add_thumbnail": false,
         "subtitle": false,

--- a/tubearchivist/home/src/download/yt_dlp_handler.py
+++ b/tubearchivist/home/src/download/yt_dlp_handler.py
@@ -312,6 +312,8 @@ class VideoDownloader:
         """build user customized options"""
         if self.config["downloads"]["format"]:
             self.obs["format"] = self.config["downloads"]["format"]
+        if self.config["downloads"]["format_sort"]:
+            self.obs["format_sort"] = self.config["downloads"]["format_sort"].split(",")
         if self.config["downloads"]["limit_speed"]:
             self.obs["ratelimit"] = (
                 self.config["downloads"]["limit_speed"] * 1024

--- a/tubearchivist/home/src/download/yt_dlp_handler.py
+++ b/tubearchivist/home/src/download/yt_dlp_handler.py
@@ -313,7 +313,9 @@ class VideoDownloader:
         if self.config["downloads"]["format"]:
             self.obs["format"] = self.config["downloads"]["format"]
         if self.config["downloads"]["format_sort"]:
-            self.obs["format_sort"] = self.config["downloads"]["format_sort"].split(",")
+            format_sort = self.config["downloads"]["format_sort"]
+            format_sort_list = [i.strip() for i in format_sort.split(",")]
+            self.obs["format_sort"] = format_sort_list
         if self.config["downloads"]["limit_speed"]:
             self.obs["ratelimit"] = (
                 self.config["downloads"]["limit_speed"] * 1024

--- a/tubearchivist/home/src/frontend/forms.py
+++ b/tubearchivist/home/src/frontend/forms.py
@@ -113,6 +113,7 @@ class ApplicationSettingsForm(forms.Form):
     downloads_sleep_interval = forms.IntegerField(required=False)
     downloads_autodelete_days = forms.IntegerField(required=False)
     downloads_format = forms.CharField(required=False)
+    downloads_format_sort = forms.CharField(required=False)
     downloads_add_metadata = forms.ChoiceField(
         widget=forms.Select, choices=METADATA_CHOICES, required=False
     )

--- a/tubearchivist/home/templates/home/settings.html
+++ b/tubearchivist/home/templates/home/settings.html
@@ -104,7 +104,7 @@
                     <li><span class="settings-current">res,codec:av1</span>: prefer AV1 over all other video codecs.</li>
                     <li><span class="settings-current">0</span>: deactivate and keep the default as decided by yt-dlp.</li>
                 </ul>
-                <i>Check out the <a href="https://github.com/yt-dlp/yt-dlp#sorting-formats" target="_blank">documentation</a> for valid configurations.</i><br>
+                <i>Not all codecs are supported by all browsers. The default value ensures best compatibility. Check out the <a href="https://github.com/yt-dlp/yt-dlp#sorting-formats" target="_blank">documentation</a> for valid configurations.</i><br>
                 {{ app_form.downloads_format_sort }}
                 <br>
             </div>

--- a/tubearchivist/home/templates/home/settings.html
+++ b/tubearchivist/home/templates/home/settings.html
@@ -96,6 +96,19 @@
                 <br>
             </div>
             <div class="settings-item">
+                <p>Force sort order to have precedence over all yt-dlp fields.<br>
+                    Currently: <span class="settings-current">{{ config.downloads.format_sort }}</span>
+                </p>
+                <p>Example configurations:</p>
+                <ul>
+                    <li><span class="settings-current">res,codec:av1</span>: prefer AV1 over all other video codecs.</li>
+                    <li><span class="settings-current">0</span>: deactivate and keep the default as decided by yt-dlp.</li>
+                </ul>
+                <i>Check out the <a href="https://github.com/yt-dlp/yt-dlp#sorting-formats" target="_blank">documentation</a> for valid configurations.</i><br>
+                {{ app_form.downloads_format_sort }}
+                <br>
+            </div>
+            <div class="settings-item">
                 <p>Current metadata embed setting: <span class="settings-current">{{ config.downloads.add_metadata }}</span></p>
                 <i>Metadata is not embedded into the downloaded files by default.</i><br>
                 {{ app_form.downloads_add_metadata }}


### PR DESCRIPTION
This exposes the [`--format-sort`][1] yt-dlp option to the user.

Implements parts of #316

[1]: https://github.com/yt-dlp/yt-dlp#sorting-formats

