### PR TITLE
Add `reindex` notifications category to Downloads tab

### DIFF
--- a/tubearchivist/home/templates/home/downloads.html
+++ b/tubearchivist/home/templates/home/downloads.html
@@ -5,7 +5,7 @@
     <div class="title-bar">
         <h1>Downloads {% if channel_filter_id %} for {{ channel_filter_name }}{% endif %}</h1>
     </div>
-    <div id="notifications" data="download"></div>
+    <div id="notifications" data="download reindex"></div>
     <div id="downloadControl"></div>
     <div class="info-box info-box-3">
         <div class="icon-text">


### PR DESCRIPTION
It is somewhat weird that this particular progress seems to only be shown on a single channel view (while it's not channel-specific), and in the settings page.

I think it would make sense and be intuitive to show reindex progress on the Downloads tab. After all, you do see indexing progress there if you add up videos there manually, which is the first thing users do when trying out TA for the first time, so they grow an expectation to see the indexing-related progresses there in general I'd say...
