### PR TITLE
Add fullscreen hotkey to video player

### DIFF
--- a/tubearchivist/static/script.js
+++ b/tubearchivist/static/script.js
@@ -1483,6 +1483,23 @@ function doShortcut(e) {
       player.muted = !player.muted;
       break;
     }
+    case 'f': {
+      e.preventDefault();
+      if(document.fullscreenElement === null) {
+        player.requestFullscreen()
+        .catch(e => {
+          console.error(e);
+          showModal('Unable to enter fullscreen', 3000);
+        });
+      } else {
+        document.exitFullscreen()
+        .catch(e => {
+          console.error(e);
+          showModal('Unable to exit fullscreen', 3000);
+        });
+      }
+      break;
+    }
     case 'ArrowLeft': {
       e.preventDefault();
       showModal('- 5 seconds', 500);
@@ -1527,6 +1544,7 @@ function doShortcut(e) {
                 <table style="margin: auto; background: rgba(0,0,0,.5)"><tbody>
                 <tr><td>Show help</td><td>?</td>
                 <tr><td>Toggle mute</td><td>m</td>
+                <tr><td>Toggle fullscreen</td><td>f</td>
                 <tr><td>Toggle subtitles (if available)</td><td>c</td>
                 <tr><td>Increase speed</td><td>&gt;</td>
                 <tr><td>Decrease speed</td><td>&lt;</td>

--- a/tubearchivist/static/script.js
+++ b/tubearchivist/static/script.js
@@ -1485,15 +1485,13 @@ function doShortcut(e) {
     }
     case 'f': {
       e.preventDefault();
-      if(document.fullscreenElement === null) {
-        player.requestFullscreen()
-        .catch(e => {
+      if (document.fullscreenElement === null) {
+        player.requestFullscreen().catch(e => {
           console.error(e);
           showModal('Unable to enter fullscreen', 3000);
         });
       } else {
-        document.exitFullscreen()
-        .catch(e => {
+        document.exitFullscreen().catch(e => {
           console.error(e);
           showModal('Unable to exit fullscreen', 3000);
         });


### PR DESCRIPTION
When browsing videos online, I often use the `f` hotkey to toggle fullscreen. It seems like the native player in Chrome and Firefox didn't support this, so I attempted to add it.

A few things I'm unsure about:
- This is the first time I'm using the fullscreen API and I may have missed some gotchas
- [`document.exitfullScreen`](https://caniuse.com/?search=document.exitfullScreen) and [`requestFullscreen`](https://caniuse.com/?search=requestFullscreen) are only supported by 80% of devices
- According to the caniuse above, this solution will not work on iphones. I'm not sure if there's a solution as I don't have an iphone to test with
