### PR TITLE
Fix links to settings documentation

### DIFF
--- a/tubearchivist/home/templates/home/settings_actions.html
+++ b/tubearchivist/home/templates/home/settings_actions.html
@@ -12,7 +12,7 @@
 </div>
 <div class="settings-group">
     <h2>Manual media files import.</h2>
-    <p>Add files to the <span class="settings-current">cache/import</span> folder. Make sure to follow the instructions in the Github <a href="https://docs.tubearchivist.com/settings/" target="_blank">Wiki</a>.</p>
+    <p>Add files to the <span class="settings-current">cache/import</span> folder. Make sure to follow the instructions in the Github <a href="https://docs.tubearchivist.com/settings/actions/#manual-media-files-import" target="_blank">Wiki</a>.</p>
     <div id="manual-import">
         <button onclick="manualImport()">Start import</button>
     </div>
@@ -58,7 +58,7 @@
 <div class="settings-group">
     <h2>Rescan filesystem</h2>
     <p><span class="danger-zone">Danger Zone</span>: This will delete the metadata of deleted videos from the filesystem.</p>
-    <p>Rescan your media folder looking for missing videos and clean up index. More infos on the Github <a href="https://docs.tubearchivist.com/settings/" target="_blank">Wiki</a>.</p>
+    <p>Rescan your media folder looking for missing videos and clean up index. More infos on the Github <a href="https://docs.tubearchivist.com/settings/actions/#rescan-filesystem" target="_blank">Wiki</a>.</p>
     <div id="fs-rescan">
         <button onclick="fsRescan()">Rescan filesystem</button>
     </div>

--- a/tubearchivist/home/templates/home/settings_application.html
+++ b/tubearchivist/home/templates/home/settings_application.html
@@ -141,7 +141,7 @@
         <div class="settings-item">
             <p>Import YouTube cookie: <span class="settings-current">{{ config.downloads.cookie_import }}</span><br></p>
             <p>For automatic cookie import use <b>Tube Archivist Companion</b> <a href="https://github.com/tubearchivist/browser-extension" target="_blank">browser extension</a>.</p> 
-            <i>For manual cookie import, place your cookie file named <span class="settings-current">cookies.google.txt</span> in <span class="settings-current">cache/import</span> before enabling. Instructions in the <a href="https://docs.tubearchivist.com/settings/" target="_blank">Wiki.</a></i><br>
+            <i>For manual cookie import, place your cookie file named <span class="settings-current">cookies.google.txt</span> in <span class="settings-current">cache/import</span> before enabling. Instructions in the <a href="https://docs.tubearchivist.com/settings/application/#cookie" target="_blank">Wiki.</a></i><br>
             {{ app_form.downloads_cookie_import }}<br>
             {% if config.downloads.cookie_import %}
                 <div id="cookieMessage">
@@ -174,7 +174,7 @@
         <h2 id="snapshots">Snapshots</h2>
         <div class="settings-item">
             <p>Current system snapshot: <span class="settings-current">{{ config.application.enable_snapshot }}</span></p>
-            <i>Automatically create daily deduplicated snapshots of the index, stored in Elasticsearch. Read first before activating: <a target="_blank" href="https://docs.tubearchivist.com/settings/#snapshots">Wiki</a>.</i><br>
+            <i>Automatically create daily deduplicated snapshots of the index, stored in Elasticsearch. Read first before activating: <a target="_blank" href="https://docs.tubearchivist.com/settings/application/#snapshots">Wiki</a>.</i><br>
             {{ app_form.application_enable_snapshot }}
         </div>
         <div>


### PR DESCRIPTION
I noticed that the `Wiki` links where broken after the split by https://github.com/tubearchivist/tubearchivist/pull/528 & https://github.com/tubearchivist/docs/pull/19

And i made some of the links more precise.

---

For the url in `docs/Settings.md`  i was not sure which path to set,
because the `/settings/` is not a valid route anymore and returns `403 Forbidden`