### PR TITLE
Remove repo docs in favor of hosted docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,8 +17,5 @@ venv/
 # Unneeded graphics
 assets/*
 
-# Unneeded docs
-docs/*
-
 # for local testing only
 testing.sh

--- a/docs/Channels.md
+++ b/docs/Channels.md
@@ -1,3 +1,0 @@
-All user documentation has moved to a more flexible, easier to extend and modify documentation platform accessible [here](https://docs.tubearchivist.com) and built from [here](https://github.com/tubearchivist/docs). Don't make any more changes here, keeping this around for some time to keep old links alive.
-
-Equivalent Channels page is: [here](https://docs.tubearchivist.com/channels/).

--- a/docs/Downloads.md
+++ b/docs/Downloads.md
@@ -1,3 +1,0 @@
-All user documentation has moved to a more flexible, easier to extend and modify documentation platform accessible [here](https://docs.tubearchivist.com) and built from [here](https://github.com/tubearchivist/docs). Don't make any more changes here, keeping this around for some time to keep old links alive.
-
-Equivalent Downloads page is: [here](https://docs.tubearchivist.com/downloads/).

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,3 +1,0 @@
-All user documentation has moved to a more flexible, easier to extend and modify documentation platform accessible [here](https://docs.tubearchivist.com) and built from [here](https://github.com/tubearchivist/docs). Don't make any more changes here, keeping this around for some time to keep old links alive.
-
-Equivalent FAQ page is: [here](https://docs.tubearchivist.com/faq/).

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,1 +1,0 @@
-All user documentation has moved to a more flexible, easier to extend and modify documentation platform accessible [here](https://docs.tubearchivist.com) and built from [here](https://github.com/tubearchivist/docs). Don't make any more changes here, keeping this around for some time to keep old links alive.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -1,3 +1,0 @@
-All user documentation has moved to a more flexible, easier to extend and modify documentation platform accessible [here](https://docs.tubearchivist.com) and built from [here](https://github.com/tubearchivist/docs). Don't make any more changes here, keeping this around for some time to keep old links alive.
-
-Equivalent pages are located under *installation* on the left.

--- a/docs/Playlists.md
+++ b/docs/Playlists.md
@@ -1,3 +1,0 @@
-All user documentation has moved to a more flexible, easier to extend and modify documentation platform accessible [here](https://docs.tubearchivist.com) and built from [here](https://github.com/tubearchivist/docs). Don't make any more changes here, keeping this around for some time to keep old links alive.
-
-Equivalent Playlist page is: [here](https://docs.tubearchivist.com/playlists/).

--- a/docs/Search.md
+++ b/docs/Search.md
@@ -1,3 +1,0 @@
-All user documentation has moved to a more flexible, easier to extend and modify documentation platform accessible [here](https://docs.tubearchivist.com) and built from [here](https://github.com/tubearchivist/docs). Don't make any more changes here, keeping this around for some time to keep old links alive.
-
-Equivalent Search page is: [here](https://docs.tubearchivist.com/search/).

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -1,3 +1,0 @@
-All user documentation has moved to a more flexible, easier to extend and modify documentation platform accessible [here](https://docs.tubearchivist.com) and built from [here](https://github.com/tubearchivist/docs). Don't make any more changes here, keeping this around for some time to keep old links alive.
-
-Equivalent Settings page is: [here](https://docs.tubearchivist.com/settings/).

--- a/docs/Users.md
+++ b/docs/Users.md
@@ -1,3 +1,0 @@
-All user documentation has moved to a more flexible, easier to extend and modify documentation platform accessible [here](https://docs.tubearchivist.com) and built from [here](https://github.com/tubearchivist/docs). Don't make any more changes here, keeping this around for some time to keep old links alive.
-
-Equivalent Users page is: [here](https://docs.tubearchivist.com/users/).

--- a/docs/Video.md
+++ b/docs/Video.md
@@ -1,3 +1,0 @@
-All user documentation has moved to a more flexible, easier to extend and modify documentation platform accessible [here](https://docs.tubearchivist.com) and built from [here](https://github.com/tubearchivist/docs). Don't make any more changes here, keeping this around for some time to keep old links alive.
-
-Equivalent Video page is: [here](https://docs.tubearchivist.com/video/).


### PR DESCRIPTION
Removing the old repository docs as suggested by https://github.com/tubearchivist/tubearchivist/pull/535#issuecomment-1704322122

For someone stumbling on this pull request, docs are here now: https://docs.tubearchivist.com/