### PR TITLE
Support elasticsearch clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Take a look at the example [docker-compose.yml](https://github.com/tubearchivist
 | TA_PORT | Overwrite Nginx port | Optional |
 | TA_UWSGI_PORT | Overwrite container internal uwsgi port | Optional |
 | ES_URL | URL That ElasticSearch runs on | Optional |
+| ES_VERIFY_SSL | Verify ElasticSearch SSL certificate, everything other than `false` defaults to `true` | Optional |
+| ES_SNAPSHOT_DIR | Custom path where elastic search stores snapshots for master/data nodes | Optional |
 | HOST_GID | Allow TA to own the video files instead of container user | Optional |
 | HOST_UID | Allow TA to own the video files instead of container user | Optional |
 | ELASTIC_USER | Change the default ElasticSearch user | Optional |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Take a look at the example [docker-compose.yml](https://github.com/tubearchivist
 | TA_PORT | Overwrite Nginx port | Optional |
 | TA_UWSGI_PORT | Overwrite container internal uwsgi port | Optional |
 | ES_URL | URL That ElasticSearch runs on | Optional |
-| ES_VERIFY_SSL | Verify ElasticSearch SSL certificate, everything other than `false` defaults to `true` | Optional |
+| ES_DISABLE_VERIFY_SSL | Disable ElasticSearch SSL certificate verification | Optional |
 | ES_SNAPSHOT_DIR | Custom path where elastic search stores snapshots for master/data nodes | Optional |
 | HOST_GID | Allow TA to own the video files instead of container user | Optional |
 | HOST_UID | Allow TA to own the video files instead of container user | Optional |

--- a/tubearchivist/home/src/es/connect.py
+++ b/tubearchivist/home/src/es/connect.py
@@ -27,7 +27,7 @@ class ElasticWrap:
         self.url: str = f"{self.ES_URL}/{path}"
         self.auth: tuple[str, str] = (self.ES_USER, self.ES_PASS)
 
-        if not self.ES_DISABLE_VERIFY_SSL:
+        if self.ES_DISABLE_VERIFY_SSL:
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     def get(

--- a/tubearchivist/home/src/es/connect.py
+++ b/tubearchivist/home/src/es/connect.py
@@ -7,6 +7,7 @@ functionality:
 
 import json
 import os
+from typing import Any
 
 import requests
 import urllib3
@@ -20,75 +21,93 @@ class ElasticWrap:
     ES_URL: str = str(os.environ.get("ES_URL"))
     ES_PASS: str = str(os.environ.get("ELASTIC_PASSWORD"))
     ES_USER: str = str(os.environ.get("ELASTIC_USER") or "elastic")
-    ES_VERIFY_SSL: str = str(os.environ.get("ES_VERIFY_SSL") or "true")
+    ES_DISABLE_VERIFY_SSL: bool = bool(os.environ.get("ES_DISABLE_VERIFY_SSL"))
 
-    def __init__(self, path):
-        self.url = f"{self.ES_URL}/{path}"
-        self.auth = (self.ES_USER, self.ES_PASS)
-        self.verify_ssl = self.ES_VERIFY_SSL != "false"
+    def __init__(self, path: str):
+        self.url: str = f"{self.ES_URL}/{path}"
+        self.auth: tuple[str, str] = (self.ES_USER, self.ES_PASS)
 
-        if not self.verify_ssl:
+        if not self.ES_DISABLE_VERIFY_SSL:
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-    def get(self, data=False, timeout=10, print_error=True):
+    def get(
+        self,
+        data: bool | dict = False,
+        timeout: int = 10,
+        print_error: bool = True,
+    ) -> tuple[dict, int]:
         """get data from es"""
+
+        kwargs: dict[str, Any] = {
+            "auth": self.auth,
+            "timeout": timeout,
+        }
+
+        if self.ES_DISABLE_VERIFY_SSL:
+            kwargs["verify"] = False
+
         if data:
-            response = requests.get(
-                self.url,
-                json=data,
-                auth=self.auth,
-                timeout=timeout,
-                verify=self.verify_ssl,
-            )
-        else:
-            response = requests.get(
-                self.url,
-                auth=self.auth,
-                timeout=timeout,
-                verify=self.verify_ssl,
-            )
+            kwargs["json"] = data
+
+        response = requests.get(self.url, **kwargs)
+
         if print_error and not response.ok:
             print(response.text)
 
         return response.json(), response.status_code
 
-    def post(self, data=False, ndjson=False):
+    def post(
+        self, data: bool | dict = False, ndjson: bool = False
+    ) -> tuple[dict, int]:
         """post data to es"""
-        if ndjson:
-            headers = {"Content-type": "application/x-ndjson"}
-            payload = data
-        else:
-            headers = {"Content-type": "application/json"}
-            payload = json.dumps(data)
 
-        if data:
-            response = requests.post(
-                self.url,
-                data=payload,
-                headers=headers,
-                auth=self.auth,
-                verify=self.verify_ssl,
+        kwargs: dict[str, Any] = {"auth": self.auth}
+
+        if ndjson and data:
+            kwargs.update(
+                {
+                    "headers": {"Content-type": "application/x-ndjson"},
+                    "data": data,
+                }
             )
-        else:
-            response = requests.post(
-                self.url,
-                headers=headers,
-                auth=self.auth,
-                verify=self.verify_ssl,
+        elif data:
+            kwargs.update(
+                {
+                    "headers": {"Content-type": "application/json"},
+                    "data": json.dumps(data),
+                }
             )
+
+        if self.ES_DISABLE_VERIFY_SSL:
+            kwargs["verify"] = False
+
+        response = requests.post(self.url, **kwargs)
 
         if not response.ok:
             print(response.text)
 
         return response.json(), response.status_code
 
-    def put(self, data, refresh=False):
+    def put(
+        self,
+        data: bool | dict = False,
+        refresh: bool = False,
+    ) -> tuple[dict, Any]:
         """put data to es"""
+
         if refresh:
             self.url = f"{self.url}/?refresh=true"
-        response = requests.put(
-            f"{self.url}", json=data, auth=self.auth, verify=self.verify_ssl
-        )
+
+        kwargs: dict[str, Any] = {
+            "json": data,
+            "auth": self.auth,
+        }
+
+        if self.ES_DISABLE_VERIFY_SSL:
+            kwargs["verify"] = False
+
+        response = requests.put(self.url, **kwargs)
+
         if not response.ok:
             print(response.text)
             print(data)
@@ -96,18 +115,25 @@ class ElasticWrap:
 
         return response.json(), response.status_code
 
-    def delete(self, data=False, refresh=False):
+    def delete(
+        self,
+        data: bool | dict = False,
+        refresh: bool = False,
+    ) -> tuple[dict, Any]:
         """delete document from es"""
+
         if refresh:
             self.url = f"{self.url}/?refresh=true"
+
+        kwargs: dict[str, Any] = {"auth": self.auth}
+
         if data:
-            response = requests.delete(
-                self.url, json=data, auth=self.auth, verify=self.verify_ssl
-            )
-        else:
-            response = requests.delete(
-                self.url, auth=self.auth, verify=self.verify_ssl
-            )
+            kwargs["json"] = data
+
+        if self.ES_DISABLE_VERIFY_SSL:
+            kwargs["verify"] = False
+
+        response = requests.delete(self.url, **kwargs)
 
         if not response.ok:
             print(response.text)

--- a/tubearchivist/home/src/es/snapshot.py
+++ b/tubearchivist/home/src/es/snapshot.py
@@ -19,7 +19,9 @@ class ElasticSnapshot:
     REPO_SETTINGS = {
         "compress": "true",
         "chunk_size": "1g",
-        "location": "/usr/share/elasticsearch/data/snapshot",
+        "location": environ.get(
+            "ES_SNAPSHOT_DIR", "/usr/share/elasticsearch/data/snapshot"
+        ),
     }
     POLICY = "ta_daily"
 


### PR DESCRIPTION
This project is very opinionated when it comes for handling elasticsearch, and assumes only one ES node on one host. However it will be nice, to also support elasticsearch clusters (for example in k8s environments). This PR adds small tweaks here and there to make it possible.

**This PR is 100% backwards compatible.** All new settings default to previous logic.

1. Better snapshot checker

    The part of code checking for snapshots, doesn't take `role` param of ES node into consideration. It expects, all ES nodes to support snapshots, which is not the case in clustered environment. Only `data_*` and `master` nodes can have snapshots, other ones (especially `coordinating` and `ingest` nodes) doesn't allow it, so for these this check will fail. The PR takes that into consideration, and do the checks only on master/data nodes.

2. Customizable snapshot dir

    Snapshot dir is currently hardcoded to `/usr/share/elasticsearch/data/snapshot`. This is not always the case, and depends heavily on ES cluster configuration. I introduced new env variable `ES_SNAPSHOT_DIR` which defaults to `/usr/share/elasticsearch/data/snapshot` (for backwards compatibility) but also allows to customize this path.

3. Support for unverified SSL in elasticsearch

    Currently SSL is allowed for ES endpoint (by simply providing `https:` scheme), but requires trusted certificate - which may not always be the case (especially in internally-networked environments like kubernetes). The new `ES_VERIFY_SSL` allows to disable this verification while still using SSL. It must be explicitly set to `false` - everything else (including not setting it at all) will keep it enabled (as it was before).

