### PR TITLE
Healthcheck endpoint

### DIFF
--- a/tubearchivist/config/settings.py
+++ b/tubearchivist/config/settings.py
@@ -64,6 +64,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "home.src.ta.health.HealthCheckMiddleware",
 ]
 
 ROOT_URLCONF = "config.urls"

--- a/tubearchivist/home/src/ta/health.py
+++ b/tubearchivist/home/src/ta/health.py
@@ -1,0 +1,11 @@
+from django.http import HttpResponse
+
+
+class HealthCheckMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.path == "/health":
+            return HttpResponse("ok")
+        return self.get_response(request)


### PR DESCRIPTION
This PR adds simple `/health` endpoint which is usable in docker swarm or kubernetes environments, which use periodical healthchecks of the container.