### PR TITLE
Remove /media/ prefix from Download File URL in video.html

### DIFF
--- a/tubearchivist/home/templates/home/video.html
+++ b/tubearchivist/home/templates/home/video.html
@@ -85,7 +85,7 @@
                         <button data-id="{{ video.youtube_id }}" data-type="video" onclick="reindex(this)" title="Reindex {{ video.title }}">Reindex</button>
                     </div>
                 {% endif %}
-                <a download="" href="/media/{{ video.media_url }}"><button id="download-item">Download File</button></a>
+                <a download="" href="{{ video.media_url }}"><button id="download-item">Download File</button></a>
                 <button onclick="deleteConfirm()" id="delete-item">Delete Video</button>
                 <div class="delete-confirm" id="delete-button">
                     <span>Are you sure? </span><button class="danger-button" onclick="deleteVideo(this)" data-id="{{ video.youtube_id }}" data-redirect = "{{ video.channel.channel_id }}">Delete</button> <button onclick="cancelDelete()">Cancel</button>


### PR DESCRIPTION
Hello all,
I removed the /media/ prefix from Download File URL in the video.html. I left the search processor as it's following @bbilly1 's advice.
This is my first contribution to open source! If other modifications are required or I made mistakes please notify me.