### PR TITLE
Fix `textarea` type from `shell` to `Shell`.

### DIFF
--- a/.github/ISSUE_TEMPLATE/INSTALLATION-HELP.yml
+++ b/.github/ISSUE_TEMPLATE/INSTALLATION-HELP.yml
@@ -38,6 +38,6 @@ body:
     attributes:
       label: Relevant log output
       description: Please copy and paste any relevant Docker logs. This will be automatically formatted into code, so no need for backticks.
-      render: shell
+      render: Shell
     validations:
       required: true


### PR DESCRIPTION
Fix `textarea` render type, changing it from `shell` to `Shell`. Noticed this issue when setting up other project (Plex integration).