### PR TITLE
Add `allowed_null_keys` and its dictionary for manual imports.

### DIFF
--- a/tubearchivist/home/src/index/manual.py
+++ b/tubearchivist/home/src/index/manual.py
@@ -427,17 +427,8 @@ class ManualImport:
         if not self.current_video["metadata"]:
             return False
 
-        allowed_null_keys = [
-            "description",
-            "categories",
-            "thumbnail",
-            "tags",
-            "view_count",
-        ]
-        default_null = dict.fromkeys(allowed_null_keys, None)
-
         with open(self.current_video["metadata"], "r", encoding="utf-8") as f:
-            info_json = json.loads(f.read(), object_hook=default_null)
+            info_json = json.loads(f.read())
 
         return info_json
 

--- a/tubearchivist/home/src/index/manual.py
+++ b/tubearchivist/home/src/index/manual.py
@@ -427,7 +427,13 @@ class ManualImport:
         if not self.current_video["metadata"]:
             return False
         
-        allowed_null_keys = ["description", "categories", "thumbnail", "tags", "view_count"]
+        allowed_null_keys = [
+            "description",
+            "categories",
+            "thumbnail",
+            "tags",
+            "view_count"
+        ]
         default_null = dict.fromkeys(allowed_null_keys, None)
 
         with open(self.current_video["metadata"], "r", encoding="utf-8") as f:

--- a/tubearchivist/home/src/index/manual.py
+++ b/tubearchivist/home/src/index/manual.py
@@ -427,6 +427,7 @@ class ManualImport:
         if not self.current_video["metadata"]:
             return False
         
+        
         allowed_null_keys = [
             "description",
             "categories",

--- a/tubearchivist/home/src/index/manual.py
+++ b/tubearchivist/home/src/index/manual.py
@@ -432,7 +432,7 @@ class ManualImport:
             "categories",
             "thumbnail",
             "tags",
-            "view_count"
+            "view_count",
         ]
         default_null = dict.fromkeys(allowed_null_keys, None)
 

--- a/tubearchivist/home/src/index/manual.py
+++ b/tubearchivist/home/src/index/manual.py
@@ -427,7 +427,6 @@ class ManualImport:
         if not self.current_video["metadata"]:
             return False
 
-
         allowed_null_keys = [
             "description",
             "categories",

--- a/tubearchivist/home/src/index/manual.py
+++ b/tubearchivist/home/src/index/manual.py
@@ -426,9 +426,12 @@ class ManualImport:
         """read info_json from file"""
         if not self.current_video["metadata"]:
             return False
+        
+        allowed_null_keys = ["description", "categories", "thumbnail", "tags", "view_count"]
+        default_null = dict.fromkeys(allowed_null_keys, None)
 
         with open(self.current_video["metadata"], "r", encoding="utf-8") as f:
-            info_json = json.loads(f.read())
+            info_json = json.loads(f.read(), object_hook=default_null)
 
         return info_json
 

--- a/tubearchivist/home/src/index/manual.py
+++ b/tubearchivist/home/src/index/manual.py
@@ -426,8 +426,8 @@ class ManualImport:
         """read info_json from file"""
         if not self.current_video["metadata"]:
             return False
-        
-        
+
+
         allowed_null_keys = [
             "description",
             "categories",

--- a/tubearchivist/home/src/index/video.py
+++ b/tubearchivist/home/src/index/video.py
@@ -189,7 +189,7 @@ class YoutubeVideo(YouTubeItem, YoutubeSubtitle):
         self.json_data = {
             "title": self.youtube_meta["title"],
             "description": self.youtube_meta.get("description", ""),
-            "category": self.youtube_meta.get("categories",[]),
+            "category": self.youtube_meta.get("categories", []),
             "vid_thumb_url": self.youtube_meta["thumbnail"],
             "vid_thumb_base64": base64_blur,
             "tags": self.youtube_meta.get("tags", []),

--- a/tubearchivist/home/src/index/video.py
+++ b/tubearchivist/home/src/index/video.py
@@ -188,11 +188,11 @@ class YoutubeVideo(YouTubeItem, YoutubeSubtitle):
         # build json_data basics
         self.json_data = {
             "title": self.youtube_meta["title"],
-            "description": self.youtube_meta["description"],
-            "category": self.youtube_meta["categories"],
+            "description": self.youtube_meta.get("description", ""),
+            "category": self.youtube_meta.get("categories",[]),
             "vid_thumb_url": self.youtube_meta["thumbnail"],
             "vid_thumb_base64": base64_blur,
-            "tags": self.youtube_meta["tags"],
+            "tags": self.youtube_meta.get("tags", []),
             "published": published,
             "vid_last_refresh": last_refresh,
             "date_downloaded": last_refresh,


### PR DESCRIPTION
Create default dictionary for allowed null inputs within manual imports. Related to https://github.com/tubearchivist/tubearchivist/issues/581. 