### PR TITLE
Add new CSS item for footer text centering

### DIFF
--- a/tubearchivist/static/css/style.css
+++ b/tubearchivist/static/css/style.css
@@ -180,6 +180,10 @@ button:hover {
     text-decoration: underline;
 }
 
+.footer .boxed-content {
+    text-align: center;
+}
+
 /* toggle on-off */
 .toggle {
     display: flex;


### PR DESCRIPTION
Add CSS style to center the text in the footer.

Text was left-aligned which on setups with more than 3 columns starts to feel out-of-place.

This matches the mobile style of centering the text as well.