### PR TITLE
Fix #616 - fix Chromium scaling issues

### DIFF
--- a/tubearchivist/home/templates/home/base.html
+++ b/tubearchivist/home/templates/home/base.html
@@ -35,12 +35,12 @@
         <div class="boxed-content">
             <div class="top-banner">
                 <a href="{% url 'home' %}">
-                    <img id="top-banner-img" alt="tube-archivist-banner">
-                    <script>
-                        var src = getComputedStyle(document.body).getPropertyValue("--banner");
-                        src = src.replace(/\"/g, "");
-                        var img = document.getElementById("top-banner-img");
-                        img.setAttribute("src", src);
+                    <img alt="tube-archivist-banner">
+                    <script type="text/javascript">
+                        setImg(
+                            document.querySelector(".top-banner img"),
+                            getComputedStyle(document.body).getPropertyValue("--banner")
+                        );
                     </script>
                 </a>
             </div>

--- a/tubearchivist/home/templates/home/base.html
+++ b/tubearchivist/home/templates/home/base.html
@@ -35,7 +35,13 @@
         <div class="boxed-content">
             <div class="top-banner">
                 <a href="{% url 'home' %}">
-                    <img alt="tube-archivist-banner">
+                    <img id="top-banner-img" alt="tube-archivist-banner">
+                    <script>
+                        var src = getComputedStyle(document.body).getPropertyValue("--banner");
+                        src = src.replace(/\"/g, "");
+                        var img = document.getElementById("top-banner-img");
+                        img.setAttribute("src", src);
+                    </script>
                 </a>
             </div>
             <div class="top-nav">

--- a/tubearchivist/home/templates/home/login.html
+++ b/tubearchivist/home/templates/home/login.html
@@ -22,7 +22,13 @@
 </head>
 <body>
     <div class="boxed-content login-page">
-        <img alt="tube-archivist-logo">
+        <img id="logo-img" alt="tube-archivist-banner">
+        <script>
+            var src = getComputedStyle(document.body).getPropertyValue("--logo");
+            src = src.replace(/\"/g, "");
+            var img = document.getElementById("logo-img");
+            img.setAttribute("src", src);
+        </script>
         <h1>Tube Archivist</h1>
         <h2>Your Self Hosted YouTube Media Server</h2>
         {% if form_error %}

--- a/tubearchivist/home/templates/home/login.html
+++ b/tubearchivist/home/templates/home/login.html
@@ -19,16 +19,17 @@
     <meta name="msapplication-config" content="{% static 'favicon/browserconfig.xml' %}">
     <meta name="theme-color" content="#01202e">
     <link rel="stylesheet" href="{% static 'css/' %}{{ stylesheet }}">
+    <script type="text/javascript" src="{% static 'script.js' %}"></script>
 </head>
 <body>
     <div class="boxed-content login-page">
-        <img id="logo-img" alt="tube-archivist-banner">
-        <script>
-            var src = getComputedStyle(document.body).getPropertyValue("--logo");
-            src = src.replace(/\"/g, "");
-            var img = document.getElementById("logo-img");
-            img.setAttribute("src", src);
-        </script>
+        <img alt="tube-archivist-logo">
+        <script type="text/javascript">
+            setImg(
+                document.querySelector(".login-page img"),
+                getComputedStyle(document.body).getPropertyValue("--logo")
+            );
+            </script>
         <h1>Tube Archivist</h1>
         <h2>Your Self Hosted YouTube Media Server</h2>
         {% if form_error %}

--- a/tubearchivist/static/css/dark.css
+++ b/tubearchivist/static/css/dark.css
@@ -9,6 +9,6 @@
     --accent-font-light: #97d4c8;
     --img-filter: invert(50%) sepia(9%) saturate(2940%) hue-rotate(122deg) brightness(94%) contrast(90%);
     --img-filter-error: invert(16%) sepia(60%) saturate(3717%) hue-rotate(349deg) brightness(86%) contrast(120%);
-    --banner: url("../img/banner-tube-archivist-dark.png");
-    --logo: url("../img/logo-tube-archivist-dark.png");
+    --banner: "/static/img/banner-tube-archivist-dark.png";
+    --logo: "/static/img/logo-tube-archivist-dark.png";
 }

--- a/tubearchivist/static/css/light.css
+++ b/tubearchivist/static/css/light.css
@@ -9,6 +9,6 @@
     --accent-font-light: #35b399;
     --img-filter: invert(50%) sepia(9%) saturate(2940%) hue-rotate(122deg) brightness(94%) contrast(90%);
     --img-filter-error: invert(16%) sepia(60%) saturate(3717%) hue-rotate(349deg) brightness(86%) contrast(120%);
-    --banner: url("../img/banner-tube-archivist-light.png");
-    --logo: url("../img/logo-tube-archivist-light.png");
+    --banner: "static/img/banner-tube-archivist-light.png";
+    --logo: "static/img/logo-tube-archivist-light.png";
 }

--- a/tubearchivist/static/css/matrix.css
+++ b/tubearchivist/static/css/matrix.css
@@ -9,8 +9,8 @@
     --accent-font-light: #00aa00;
     --img-filter: brightness(0) saturate(100%) invert(45%) sepia(100%) saturate(3710%) hue-rotate(96deg) brightness(100%) contrast(102%);
     --img-filter-error: invert(16%) sepia(60%) saturate(3717%) hue-rotate(349deg) brightness(86%) contrast(120%);
-    --banner: url("../img/banner-tube-archivist-dark.png");
-    --logo: url("../img/logo-tube-archivist-dark.png");
+    --banner: "/static/img/banner-tube-archivist-dark.png";
+    --logo: "/static/img/logo-tube-archivist-dark.png";
     --outline: 1px solid green;
     --filter: hue-rotate(310deg);
 }

--- a/tubearchivist/static/css/midnight.css
+++ b/tubearchivist/static/css/midnight.css
@@ -9,6 +9,6 @@
     --accent-font-light: #999999;
     --img-filter: invert(50%) sepia(9%) saturate(2940%) hue-rotate(122deg) brightness(94%) contrast(90%);
     --img-filter-error: invert(16%) sepia(60%) saturate(3717%) hue-rotate(349deg) brightness(86%) contrast(120%);
-    --banner: url("../img/banner-tube-archivist-dark.png");
-    --logo: url("../img/logo-tube-archivist-dark.png");
+    --banner: "/static/img/banner-tube-archivist-dark.png";
+    --logo: "/static/img/logo-tube-archivist-dark.png";
 }

--- a/tubearchivist/static/css/style.css
+++ b/tubearchivist/static/css/style.css
@@ -165,7 +165,6 @@ button:hover {
 .top-banner img {
     width: 100%;
     max-width: 700px;
-    content: var(--banner);
 }
 
 .footer {

--- a/tubearchivist/static/css/style.css
+++ b/tubearchivist/static/css/style.css
@@ -729,7 +729,6 @@ video:-webkit-full-screen {
     max-width: 200px;
     max-height: 200px;
     margin-bottom: 40px;
-    content: var(--logo);
 }
 
 .login-page form {

--- a/tubearchivist/static/script.js
+++ b/tubearchivist/static/script.js
@@ -1567,6 +1567,6 @@ function doShortcut(e) {
 // Set img src attribute from value meant for stylesheets
 // Needed to fix scaling issues with Chromium
 function setImg(img, src) {
-  src = src.replace(/\"/g, "");
-  img.setAttribute("src", src);
+  src = src.replace(/["']/g, '');
+  img.setAttribute('src', src);
 }

--- a/tubearchivist/static/script.js
+++ b/tubearchivist/static/script.js
@@ -1563,3 +1563,10 @@ function doShortcut(e) {
     }
   }
 }
+
+// Set img src attribute from value meant for stylesheets
+// Needed to fix scaling issues with Chromium
+function setImg(img, src) {
+  src = src.replace(/\"/g, "");
+  img.setAttribute("src", src);
+}


### PR DESCRIPTION
This fix removes the `content` attribute and directly writes to the element by getting the `--banner` or `--logo` variable from the stylesheet and adds a `src` attribute. This isn't my area of expertise so feedback is appreciated.