### PR TITLE
 [Feature Request]: Add Copy button for API Key #610

### DIFF
--- a/tubearchivist/home/templates/home/settings_application.html
+++ b/tubearchivist/home/templates/home/settings_application.html
@@ -155,7 +155,8 @@
         <div class="settings-item">
             <p>API token: <button type="button" onclick="textReveal(this)" id="text-reveal-button">Show</button></p>
             <div id="text-reveal" class="description-text">
-                <p>{{ api_token }}</p>
+                <p id="text-token">{{ api_token }}</p>
+                <button type="button" onclick="textCopy()" id="text-copy-button">Copy</button>
                 <button class="danger-button" type="button" onclick="resetToken()">Revoke</button>
             </div>
         </div>

--- a/tubearchivist/static/script.js
+++ b/tubearchivist/static/script.js
@@ -1344,6 +1344,43 @@ function textReveal(button) {
   }
 }
 
+async function copyToClipboard(textToCopy) {
+  // Navigator clipboard api needs a secure context (https)
+  if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(textToCopy);
+  } else {
+      // Use the 'out of viewport hidden text area' trick
+      const textArea = document.createElement("textarea");
+      textArea.value = textToCopy;
+          
+      // Move textarea out of the viewport so it's not visible
+      textArea.style.position = "absolute";
+      textArea.style.left = "-999999px";
+          
+      document.body.prepend(textArea);
+      textArea.select();
+
+      try {
+          document.execCommand('copy');
+      } catch (error) {
+          console.error(error);
+      } finally {
+          textArea.remove();
+      }
+  }
+}
+
+async function textCopy() {
+  let token = document.getElementById('text-token').innerHTML;
+  try {
+    await copyToClipboard(token);
+    alert("Token Copied");
+  } catch(error) {
+    console.error(error);
+  }
+}
+
+
 function textExpand() {
   let textBox = document.getElementById('text-expand');
   let button = document.getElementById('text-expand-button');


### PR DESCRIPTION
This adds the copy button. Works for me on local pc using firefox and brave browser on android. Should work in the future with https also if the documentation I read is correct. The was it is now it will fail the https and fall back to the http version.
