### PR TITLE
Update comments.py

### DIFF
--- a/tubearchivist/home/src/index/comments.py
+++ b/tubearchivist/home/src/index/comments.py
@@ -164,18 +164,16 @@ class Comments:
         self.check_config()
         if not self.is_activated:
             return
-
-        self.build_json()
-        if not self.json_data:
-            return
-
+        # check for existing comments first (could return False).
         es_comments = self.get_es_comments()
-
-        if not self.comments_format:
+        if es_comments and es_comments["comment_comments"]:
+            # don't overwrite comments in es
             return
 
-        if not self.comments_format and es_comments["comment_comments"]:
-            # don't overwrite comments in es
+        # only try to grab new comments now
+        self.build_json()
+        if not self.json_data or not self.comments_format:
+            # we didn't get data or comments
             return
 
         self.delete_comments()


### PR DESCRIPTION
Cleaned up logic, based on what I interpreted from the code: 

Only try to grab new comments from youtube if ES was empty.

Fixed an unexecuted branch compare.
The return inside "if not self.comments_format and es_comments["comment_comments"]:" could never be reached because of the comparison above it.

Fixed a potential "TypeError: 'bool' object is not subscriptable" due to indexing on es_comments when it is False.

By reducing the number of wasteful calls we can further escape throttling.   (Although if the intention is to force replacement of old comments with any new ones, then why even query ES?)

