### PR TITLE
ES index mapping: numbers should be numbers

### DIFF
--- a/tubearchivist/home/src/es/index_mapping.json
+++ b/tubearchivist/home/src/es/index_mapping.json
@@ -8,7 +8,7 @@
                 }
             },
             "expected_set": {
-                "number_of_replicas": "0"
+                "number_of_replicas": 0
             }
         },
         {
@@ -88,7 +88,7 @@
                         }
                     }
                 },
-                "number_of_replicas": "0"
+                "number_of_replicas": 0
             }
         },
         {
@@ -369,7 +369,7 @@
                         }
                     }
                 },
-                "number_of_replicas": "0"
+                "number_of_replicas": 0
             }
         },
         {
@@ -430,7 +430,7 @@
                         }
                     }
                 },
-                "number_of_replicas": "0"
+                "number_of_replicas": 0
             }
         },
         {
@@ -523,7 +523,7 @@
                         }
                     }
                 },
-                "number_of_replicas": "0"
+                "number_of_replicas": 0
             }
         },
         {
@@ -591,7 +591,7 @@
                         }
                     }
                 },
-                "number_of_replicas": "0"
+                "number_of_replicas": 0
             }
         },
         {
@@ -662,7 +662,7 @@
                         }
                     }
                 },
-                "number_of_replicas": "0"
+                "number_of_replicas": 0
             }
         }
     ]


### PR DESCRIPTION
Hi,

the number of replicas should be specified as numbers and not as strings.
it is more compatible with other solutions like zincsearch.

best regargs