### PR TITLE
Log cookiejar.LoadError from POST /api/cookie/

### DIFF
--- a/tubearchivist/home/src/download/yt_dlp_base.py
+++ b/tubearchivist/home/src/download/yt_dlp_base.py
@@ -62,8 +62,8 @@ class YtWrap:
         """make extract request"""
         try:
             response = yt_dlp.YoutubeDL(self.obs).extract_info(url)
-        except cookiejar.LoadError:
-            print("cookie file is invalid")
+        except cookiejar.LoadError as err:
+            print(f"cookie file is invalid: {err}")
             return False
         except yt_dlp.utils.ExtractorError as err:
             print(f"{url}: failed to extract with message: {err}, continue...")


### PR DESCRIPTION
Help identify the root cause for https://github.com/tubearchivist/browser-extension/issues/22. 

This would log:
```
cookie file is invalid: invalid Netscape format cookies file <_io.StringIO object at 0x7f5793dd7490>: 'payments.youtube.com\tTRUE\t/\tFALSE\t1711779732\tOTZ\t<some-value>'
```
Note: it could log out the line containing the cookie (secret) that's causing the error.
