### PR TITLE
fix: playlist not getting updated after first index

### DIFF
--- a/tubearchivist/home/src/download/queue.py
+++ b/tubearchivist/home/src/download/queue.py
@@ -227,7 +227,7 @@ class PendingList(PendingIndex):
     def _parse_playlist(self, url):
         """add all videos of playlist to list"""
         playlist = YoutubePlaylist(url)
-        playlist.build_json()
+        playlist.build_json(scrape=True)
         if not playlist.json_data:
             message = f"{playlist.youtube_id}: failed to extract metadata"
             print(message)


### PR DESCRIPTION
Addresses the bug #634 
inside playlist.py
```
    def build_json(self, scrape=False):
...
        if scrape or not self.json_data:
```
self.json_data will only be empty if the playlist has never been indexed. Since `scrape` defaults to `False`, both conditions mean subsequent playlist downloads will never do any scraping. Adding `scrape=True` to the parent call fixes this scenario (tested on my own setup). 

Note that playlists don't seem to update via subscriptions scans still. I suspect we need a similar fix there, but I don't have the bandwidth to dig into that atm.
