### PR TITLE
Fix comment author is None during comment download

### DIFF
--- a/tubearchivist/home/src/index/comments.py
+++ b/tubearchivist/home/src/index/comments.py
@@ -115,6 +115,9 @@ class Comments:
 
         time_text = time_text_datetime.strftime(format_string)
 
+        if not comment.get("author"):
+            comment["author"] = comment.get("author_id", "Unknown")
+
         cleaned_comment = {
             "comment_id": comment["id"],
             "comment_text": comment["text"].replace("\xa0", ""),


### PR DESCRIPTION
This fixes a rare edge-case that may happen during parsing of comments generated by Yt-Dlp where author is None. So we default to author_id. This can happen mostly for older YT profiles that has not set-up a @-handle.