### PR TITLE
Add support for connecting to Redis via unix socket

### DIFF
--- a/tubearchivist/home/src/ta/config.py
+++ b/tubearchivist/home/src/ta/config.py
@@ -47,8 +47,8 @@ class AppConfig:
 
                 return config
 
-            except Exception:  # pylint: disable=broad-except
-                print(f"... Redis connection failed, retry [{i}/10]")
+            except Exception as e:  # pylint: disable=broad-except
+                print(f"... Redis connection failed, retry [{i}/10]: {e}")
                 sleep(3)
 
         raise ConnectionError("failed to connect to redis")

--- a/tubearchivist/home/src/ta/settings.py
+++ b/tubearchivist/home/src/ta/settings.py
@@ -31,6 +31,9 @@ class EnvironmentSettings:
     # Redis
     REDIS_HOST: str = str(environ.get("REDIS_HOST"))
     REDIS_PORT: int = int(environ.get("REDIS_PORT", 6379))
+    REDIS_SOCKET: str | None = (
+        str(environ.get("REDIS_SOCKET")) if "REDIS_SOCKET" in environ else None
+    )
     REDIS_NAME_SPACE: str = str(environ.get("REDIS_NAME_SPACE", "ta:"))
 
     # ElasticSearch

--- a/tubearchivist/home/src/ta/ta_redis.py
+++ b/tubearchivist/home/src/ta/ta_redis.py
@@ -17,11 +17,16 @@ class RedisBase:
     NAME_SPACE: str = EnvironmentSettings.REDIS_NAME_SPACE
 
     def __init__(self):
-        self.conn = redis.Redis(
-            host=EnvironmentSettings.REDIS_HOST,
-            port=EnvironmentSettings.REDIS_PORT,
-            decode_responses=True,
-        )
+        kwargs = {
+            "decode_responses": True,
+            "host": EnvironmentSettings.REDIS_HOST,
+            "port": EnvironmentSettings.REDIS_PORT,
+        }
+
+        if EnvironmentSettings.REDIS_SOCKET:
+            kwargs["unix_socket_path"] = EnvironmentSettings.REDIS_SOCKET
+
+        self.conn = redis.Redis(**kwargs)
 
 
 class RedisArchivist(RedisBase):


### PR DESCRIPTION
Hi!

Pretty much as it says on the tin.
This adds support for a `REDIS_SOCKET` environment variable, which - if set - is used to connect to Redis instead of host + port.

The "priorization" is done by the `Redis` constructor itself, which prefers `unix_socket_path` over `host` and `port`.

A second commit (438d11b58e099f165408f8dabeb462c7d2a66d34) is included, which is a small addition to print the exception message when the connect to redis fails. Helpful to troubleshoot what is going on.

- [x] branch is based on `testing`
- [x] ran `./deploy.sh validate` on each modified file

Thanks for considering!