### PR TITLE
ci: ffmpeg 7 release version changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,13 +36,13 @@ RUN apt-get clean && apt-get -y update && apt-get -y install --no-install-recomm
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ] ; then \
     curl -s https://api.github.com/repos/yt-dlp/FFmpeg-Builds/releases/latest \
         | grep browser_download_url \
-        | grep ".*master.*linuxarm64.*tar.xz" \
+        | grep ".*linuxarm64.*tar.xz" \
         | cut -d '"' -f 4 \
         | xargs curl -L --output ffmpeg.tar.xz ; \
     else \
     curl -s https://api.github.com/repos/yt-dlp/FFmpeg-Builds/releases/latest \
         | grep browser_download_url \
-        | grep ".*master.*linux64.*tar.xz" \
+        | grep ".*linux64.*tar.xz" \
         | cut -d '"' -f 4 \
         | xargs curl -L --output ffmpeg.tar.xz ; \
     fi && \


### PR DESCRIPTION
ffmpeg recently upgraded to [major version 7](https://lwn.net/Articles/968565/). During this process, it appears that yt-dlp have changed the name of their ffmpeg builds, most notably they don't seem to include a master name anymore
```
"browser_download_url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-04-18-14-07/ffmpeg-N-114861-g7f35c999f6-linux64-gpl.tar.xz"
"browser_download_url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-04-18-14-07/ffmpeg-N-114861-g7f35c999f6-linuxarm64-gpl.tar.xz"
"browser_download_url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-04-18-14-07/ffmpeg-N-114861-g7f35c999f6-win32-gpl-shared.zip"
"browser_download_url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-04-18-14-07/ffmpeg-N-114861-g7f35c999f6-win32-gpl.zip"
"browser_download_url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-04-18-14-07/ffmpeg-N-114861-g7f35c999f6-win64-gpl-shared.zip"
"browser_download_url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-04-18-14-07/ffmpeg-N-114861-g7f35c999f6-win64-gpl.zip"
"browser_download_url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-04-18-14-07/ffmpeg-N-114861-g7f35c999f6-winarm64-gpl-shared.zip"
"browser_download_url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-04-18-14-07/ffmpeg-N-114861-g7f35c999f6-winarm64-gpl.zip"
"browser_download_url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-04-18-14-07/ffmpeg-n7.0-10-g8dfafe5366-linux64-gpl-7.0.tar.xz"
"browser_download_url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-04-18-14-07/ffmpeg-n7.0-10-g8dfafe5366-linuxarm64-gpl-7.0.tar.xz"
"browser_download_url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-04-18-14-07/ffmpeg-n7.0-10-g8dfafe5366-win32-gpl-7.0.zip"
"browser_download_url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-04-18-14-07/ffmpeg-n7.0-10-g8dfafe5366-win32-gpl-shared-7.0.zip"
"browser_download_url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-04-18-14-07/ffmpeg-n7.0-10-g8dfafe5366-win64-gpl-7.0.zip"
"browser_download_url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-04-18-14-07/ffmpeg-n7.0-10-g8dfafe5366-win64-gpl-shared-7.0.zip"
"browser_download_url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-04-18-14-07/ffmpeg-n7.0-10-g8dfafe5366-winarm64-gpl-7.0.zip"
"browser_download_url": "https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-04-18-14-07/ffmpeg-n7.0-10-g8dfafe5366-winarm64-gpl-shared-7.0.zip"
```

This changes the logic in the `Dockerfile` to exclude the master tag. We get a current result of
```
https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-04-18-14-07/ffmpeg-N-114861-g7f35c999f6-linux64-gpl.tar.xz
https://github.com/yt-dlp/FFmpeg-Builds/releases/download/autobuild-2024-04-18-14-07/ffmpeg-n7.0-10-g8dfafe5366-linux64-gpl-7.0.tar.xz
```

We may want/need to add a search for ffmpeg-n7 as I haven't read up on what builds are what