### PR TITLE
workaround issue #752

### DIFF
--- a/tubearchivist/home/src/download/yt_dlp_base.py
+++ b/tubearchivist/home/src/download/yt_dlp_base.py
@@ -10,6 +10,7 @@ from http import cookiejar
 from io import StringIO
 
 import yt_dlp
+from home.src.ta.helper import clear_dl_cache
 from home.src.ta.settings import EnvironmentSettings
 from home.src.ta.ta_redis import RedisArchivist
 
@@ -53,6 +54,9 @@ class YtWrap:
                 print(f"{url}: failed to download with message {err}")
                 if "Temporary failure in name resolution" in str(err):
                     raise ConnectionError("lost the internet, abort!") from err
+
+                # Clear download cache directory after failures
+                clear_dl_cache(EnvironmentSettings.CACHE_DIR)
 
                 return False, str(err)
 


### PR DESCRIPTION
Hello!

Users in Issue #752 noted that getting a `403: Forbidden` error on just the audio of a video will leave some artifacts behind in the download directory, which will then cause TA to fail everytime a download of the video in question is attempted.
This PR will identify the situation and clear the download cache.

Tested it with my local installation, works perfectly for me - had several 403's, all could be resumed with this patch installed.
Now, just to clarify: TA will still get an error, but you can "try again" without restarting TA.

Thanks for the great work, keep it up!