### PR TITLE
add delay to queue.py to mitigate "Sign in to confirm you’re not a bot. This helps protect our community."

### DIFF
--- a/tubearchivist/home/src/download/queue.py
+++ b/tubearchivist/home/src/download/queue.py
@@ -6,6 +6,7 @@ Functionality:
 
 import json
 from datetime import datetime
+from time import sleep
 
 from home.src.download.subscriptions import ChannelSubscription
 from home.src.download.thumbnails import ThumbManager
@@ -246,6 +247,8 @@ class PendingList(PendingIndex):
         total = len(self.missing_videos)
         videos_added = []
         for idx, (youtube_id, vid_type) in enumerate(self.missing_videos):
+            sleep_interval = self.config["downloads"].get("sleep_interval", 0)
+            sleep(sleep_interval)
             if self.task and self.task.is_stopped():
                 break
 


### PR DESCRIPTION
this adds sleep_interval to queue.py, as it was found in reindex.py. 

this helps mitigate rate-limiting errors that cause an IP to be blocked/throttled/etc when adding many videos to the download queue.  