### PR TITLE
Show a link to video/playlist/channel on YT even if deactivated

### DIFF
--- a/tubearchivist/home/templates/home/channel_id_about.html
+++ b/tubearchivist/home/templates/home/channel_id_about.html
@@ -45,11 +45,11 @@
         <div class="info-box-item">
             <div>
                 <p>Last refreshed: {{ channel_info.channel_last_refresh }}</p>
-                {% if channel_info.channel_active %}
-                    <p>Youtube: <a href="https://www.youtube.com/channel/{{ channel_info.channel_id }}" target="_blank">Active</a></p>
-                {% else %}
-                    <p>Youtube: Deactivated</p>
-                {% endif %}
+                <p>YouTube:
+                    <a href="https://www.youtube.com/channel/{{ channel_info.channel_id }}" target="_blank">
+                        {% if channel_info.channel_active %}Active{% else %}Deactivated{% endif %}
+                    </a>
+                </p>
             </div>
         </div>
         <div class="info-box-item">

--- a/tubearchivist/home/templates/home/playlist_id.html
+++ b/tubearchivist/home/templates/home/playlist_id.html
@@ -40,11 +40,11 @@
 	                        <button type="button" data-type="playlist" data-subscribe="true" data-id="{{ playlist_info.playlist_id }}" onclick="subscribeStatus(this)" title="Subscribe to {{ playlist_info.playlist_name }}">Subscribe</button>
 	                    {% endif %}
 	                </p>
-	                {% if playlist_info.playlist_active %}
-	                    <p>Youtube: <a href="https://www.youtube.com/playlist?list={{ playlist_info.playlist_id }}" target="_blank">Active</a></p>
-	                {% else %}
-	                    <p>Youtube: Deactivated</p>
-	                {% endif %}
+                    <p>YouTube:
+                        <a href="https://www.youtube.com/playlist?list={{ playlist_info.playlist_id }}" target="_blank">
+                            {% if playlist_info.playlist_active %}Active{% else %}Deactivated{% endif %}
+                        </a>
+                    </p>
                 {% endif %}
                 <button onclick="deleteConfirm()" id="delete-item">Delete Playlist</button>
                 <div class="delete-confirm" id="delete-button">

--- a/tubearchivist/home/templates/home/video.html
+++ b/tubearchivist/home/templates/home/video.html
@@ -52,11 +52,11 @@
                         <img src="{% static 'img/icon-unseen.svg' %}" alt="unseen-icon" data-id="{{ video.youtube_id }}" data-status="unwatched" onclick="updateVideoWatchStatus(this)" class="watch-button" title="Mark as watched">
                     {% endif %}
                 </p>
-                {% if video.active %}
-                    <p>Youtube: <a href="https://www.youtube.com/watch?v={{ video.youtube_id }}" target="_blank">Active</a></p>
-                {% else %}
-                    <p>Youtube: Deactivated</p>
-                {% endif %}
+                <p>YouTube:
+                    <a href="https://www.youtube.com/watch?v={{ video.youtube_id }}" target="_blank">
+                        {% if video.active %}Active{% else %}Deactivated{% endif %}
+                    </a>
+                </p>
             </div>
         </div>
         <div class="info-box-item">


### PR DESCRIPTION
Just a small patch to always link to YT, even if asset is supposedly deactivated + fix of `Youtube` to `YouTube`.

Reasoning:
- be able to open the video URL anyway to
  - check if it's really down (need to see with own eyes sometimes and mourn the fact of deletion at the source)
  - check for what reason was it removed (privated, copyright claim, ToS violation, etc.)
- the video might actually be up and the link work
  - video could have been restored in the meantime and that not picked up yet (unprivatised, counter-claim filed, ToS appeal filed, etc.)
  - TA/yt-dlp could have gotten deletion status wrong, for example due to intermittent internet connectivity issues, YouTube outage or rate limiting that was interpreted as 404 etc. (it happens ¯\\_(ツ)_/¯)

I believe this small QoL improvement is worth it, as I found myself often just copying the ID from URL manually to open the link up in YT.

I was considering making "Deactivated" link non-highlighted like a regular text, "silently clickable", but eventually decided that'd be bad for accessibility and add needless complexity in CSS for no real benefit...