### PR TITLE
add delay to queue.py to mitigate "Sign in to confirm you’re not a bot." and other errors

### DIFF
--- a/backend/download/src/queue.py
+++ b/backend/download/src/queue.py
@@ -6,6 +6,7 @@ Functionality:
 
 import json
 from datetime import datetime
+from time import sleep
 
 from appsettings.src.config import AppConfig
 from common.src.es_connect import ElasticWrap, IndexPaginate
@@ -245,7 +246,9 @@ class PendingList(PendingIndex):
 
         total = len(self.missing_videos)
         videos_added = []
+        sleep_interval = self.config["downloads"].get("sleep_interval", 0)
         for idx, (youtube_id, vid_type) in enumerate(self.missing_videos):
+            sleep(sleep_interval)
             if self.task and self.task.is_stopped():
                 break
 


### PR DESCRIPTION
this adds sleep_interval to queue.py, as it was found in reindex.py.

this helps mitigate rate-limiting errors that cause an IP to be blocked/throttled/etc when adding many videos to the download queue. 

https://github.com/tubearchivist/tubearchivist/pull/816 was the original PR, but I made it against the wrong branch (apologies). I've also took the variable definition out of the loop.
