### PR TITLE
Fix `FileNotFoundError` error when manually import media with duplicated subtitles in metadata.

### DIFF
--- a/tubearchivist/home/src/index/manual.py
+++ b/tubearchivist/home/src/index/manual.py
@@ -306,6 +306,8 @@ class ImportFolderScanner:
             if stream["codec_type"] == "subtitle":
                 lang = ISO639Utils.long2short(stream["tags"]["language"])
                 sub_path = f"{base_path}.{lang}.vtt"
+                if sub_path in current_video["subtitle"]:
+                    continue
                 self._dump_subtitle(idx, media_path, sub_path)
                 current_video["subtitle"].append(sub_path)
 


### PR DESCRIPTION
If the video metadata contains two subtitles with the same title, during manual import, there will be two records in the metadata. However, in the file system, only one subtitle file will be saved due to the identical name. This results in a `FileNotFoundError` error during subsequent file moves. This PR fixes the issue.


```
tubearchivist    | Traceback (most recent call last):
tubearchivist    |   File "/root/.local/lib/python3.11/site-packages/celery/app/trace.py", line 453, in trace_task
tubearchivist    |     R = retval = fun(*args, **kwargs)
tubearchivist    |                  ^^^^^^^^^^^^^^^^^^^^
tubearchivist    |   File "/root/.local/lib/python3.11/site-packages/celery/app/trace.py", line 736, in __protected_call__
tubearchivist    |     return self.run(*args, **kwargs)
tubearchivist    |            ^^^^^^^^^^^^^^^^^^^^^^^^^
tubearchivist    |   File "/app/home/tasks.py", line 218, in run_manual_import
tubearchivist    |     ImportFolderScanner(task=self).scan()
tubearchivist    |   File "/app/home/src/index/manual.py", line 56, in scan
tubearchivist    |     self.process_videos()
tubearchivist    |   File "/app/home/src/index/manual.py", line 147, in process_videos
tubearchivist    |     ManualImport(current_video, self.CONFIG).run()
tubearchivist    |   File "/app/home/src/index/manual.py", line 398, in run
tubearchivist    |     self._move_to_archive(json_data)
tubearchivist    |   File "/app/home/src/index/manual.py", line 461, in _move_to_archive
tubearchivist    |     shutil.move(old_path, new_path, copy_function=shutil.copyfile)
tubearchivist    |   File "/usr/local/lib/python3.11/shutil.py", line 873, in move
tubearchivist    |     copy_function(src, real_dst)
tubearchivist    |   File "/usr/local/lib/python3.11/shutil.py", line 256, in copyfile
tubearchivist    |     with open(src, 'rb') as fsrc:
tubearchivist    |          ^^^^^^^^^^^^^^^
tubearchivist    | FileNotFoundError: [Errno 2] No such file or directory: '/cache/import/xxxxxx[xxxxxx].zh.vtt'
```