### PR TITLE
Update yt-dlp to 2024.12.03

### DIFF
--- a/tubearchivist/requirements.txt
+++ b/tubearchivist/requirements.txt
@@ -11,4 +11,4 @@ requests==2.32.3
 ryd-client==0.0.6
 uWSGI==2.0.28
 whitenoise==6.8.2
-yt-dlp[default]==2024.11.4
+yt-dlp[default]==2024.12.3


### PR DESCRIPTION
The current version of yt-dlp prevents downloads, consistently returning a 403 error during the process (my installation is in a big data center). This PR addresses the issue.

**Temporary Workaround:**
To manually resolve the issue until the container image is updated, you can upgrade yt-dlp directly in the main container:
```
pip install --upgrade yt-dlp --user
```
Note: These changes will be reverted upon container restart.
