### PR TITLE
AdminWriteOnly /appsettings/config

### DIFF
--- a/backend/appsettings/views.py
+++ b/backend/appsettings/views.py
@@ -20,7 +20,7 @@ from common.serializers import (
     ErrorResponseSerializer,
 )
 from common.src.ta_redis import RedisArchivist
-from common.views_base import AdminOnly, ApiBaseView
+from common.views_base import AdminOnly, AdminWriteOnly, ApiBaseView
 from django.conf import settings
 from download.src.yt_dlp_base import CookieHandler, POTokenHandler
 from drf_spectacular.utils import OpenApiResponse, extend_schema
@@ -152,7 +152,7 @@ class AppConfigApiView(ApiBaseView):
     POST: update app settings
     """
 
-    permission_classes = [AdminOnly]
+    permission_classes = [AdminWriteOnly]
 
     @staticmethod
     @extend_schema(


### PR DESCRIPTION
In the login flow we GET /api/appsettings/config. So for non staff users to be able to login, GET requests should be available to non staff users. 

I was able to test that a non staff user was successfully able to log in after applying the patch. 