### PR TITLE
feat: healthchecks by default in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,9 @@ COPY --from=node-builder ./frontend/dist /app/static
 VOLUME /cache
 VOLUME /youtube
 
+# healthcheck
+HEALTHCHECK --interval=2m --timeout=10s --retries=3 --start-period=30s --start-interval=5s CMD curl -f http://localhost:${TA_PORT:-8000}/api/health
+
 # start
 WORKDIR /app
 EXPOSE 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,12 +20,6 @@ services:
       - TA_PASSWORD=verysecret              # your initial TA credentials
       - ELASTIC_PASSWORD=verysecret         # set password for Elasticsearch
       - TZ=America/New_York                 # set your time zone
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/api/health"]
-      interval: 2m
-      timeout: 10s
-      retries: 3
-      start_period: 30s
     depends_on:
       - archivist-es
       - archivist-redis


### PR DESCRIPTION
The healthcheck can still be overridden by the user if desired but I think this is a cleaner way to integrate. No worries if you disagree.