### PR TITLE
Fix URL params in embed player

### DIFF
--- a/frontend/src/components/EmbeddableVideoPlayer.tsx
+++ b/frontend/src/components/EmbeddableVideoPlayer.tsx
@@ -121,7 +121,11 @@ const EmbeddableVideoPlayer = ({ videoId }: EmbeddableVideoPlayerProps) => {
               alt="close-icon"
               title="Close player"
               onClick={() => {
-                setSearchParams({});
+                setSearchParams(params => {
+                  const newParams = new URLSearchParams(params);
+                  newParams.delete('videoId');
+                  return newParams;
+                });
               }}
             />
 

--- a/frontend/src/components/VideoListItem.tsx
+++ b/frontend/src/components/VideoListItem.tsx
@@ -40,7 +40,11 @@ const VideoListItem = ({
     <div className={`video-item ${viewLayout}`}>
       <a
         onClick={() => {
-          setSearchParams({ videoId: video.youtube_id });
+          setSearchParams(params => {
+            const newParams = new URLSearchParams(params);
+            newParams.set('videoId', video.youtube_id);
+            return newParams;
+          });
         }}
       >
         <div className={`video-thumb-wrap ${viewLayout}`}>


### PR DESCRIPTION
When opening/closing embedded videos, maintain existing URL parameters including pagination state. Previously, the video player would reset page to 0 and lose other query parameters.
