### PR TITLE
only stamp watched date to watched videos

### DIFF
--- a/backend/common/src/watched.py
+++ b/backend/common/src/watched.py
@@ -43,14 +43,9 @@ class WatchState:
     def change_vid_state(self):
         """change watched state of video"""
         path = f"ta_video/_update/{self.youtube_id}"
-        data = {
-            "doc": {
-                "player": {
-                    "watched": self.is_watched,
-                    "watched_date": self.stamp,
-                }
-            }
-        }
+        data = {"doc": {"player": {"watched": self.is_watched}}}
+        if self.is_watched:
+            data["doc"]["player"]["watched_date"] = self.stamp
         response, status_code = ElasticWrap(path).post(data=data)
         key = f"{self.user_id}:progress:{self.youtube_id}"
         RedisArchivist().del_message(key)


### PR DESCRIPTION
Hello!
I'm introducing a change to the logic of the /watched endpoint. 
When changing the video state, it will only stamp the watched_date to watched videos. 

As it is now, the watched_date is stamped regardless of the watched state.
As a result, when synchronizing your whole library using external plugin, eg. TubeArchivistMetadata for Jellyfin - the whole library will get stamped the watched date. 
With a combination of "delete watched" option (which only checks the watched_date) your whole library will be gone when the task is run after specified "delete watched" period.

PS:
I've fixed the "delete watched" logic in this PR https://github.com/tubearchivist/tubearchivist/pull/920