### PR TITLE
Bugfix #932: this PR resolves the error generated by the DownloadItem…

### DIFF
--- a/backend/download/serializers.py
+++ b/backend/download/serializers.py
@@ -12,7 +12,7 @@ class DownloadItemSerializer(serializers.Serializer):
 
     auto_start = serializers.BooleanField()
     channel_id = serializers.CharField()
-    channel_indexed = serializers.BooleanField()
+    channel_indexed = serializers.BooleanField(required=False)
     channel_name = serializers.CharField()
     duration = serializers.CharField()
     published = serializers.CharField()


### PR DESCRIPTION
Bugfix #932: this PR resolves the error generated by the DownloadItemSerializer as it expects to have the channel_indexed field always set.

Fixes: #932 
