### PR TITLE
Remove obsolete "version" attribute

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
   tubearchivist:
     container_name: tubearchivist


### PR DESCRIPTION
On `docker compose up` with the provided `docker-compose.yml`, the following warning is printed:

```sh
WARN[0000] docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

This removes the obsolete "version" attribute.