### PR TITLE
Add timestamp seeking

### DIFF
--- a/frontend/src/components/CommentBox.tsx
+++ b/frontend/src/components/CommentBox.tsx
@@ -37,9 +37,10 @@ export type CommentsType = {
 
 type CommentBoxProps = {
   comment: CommentsType;
+  onTimestampClick?: (seconds: number) => void;
 };
 
-const CommentBox = ({ comment }: CommentBoxProps) => {
+const CommentBox = ({ comment, onTimestampClick }: CommentBoxProps) => {
   const [showSubComments, setShowSubComments] = useState(false);
 
   const hasSubComments =
@@ -51,7 +52,7 @@ const CommentBox = ({ comment }: CommentBoxProps) => {
         {comment.comment_author}
       </h3>
       <p>
-        <Linkify>{comment.comment_text}</Linkify>
+        <Linkify onTimestampClick={onTimestampClick}>{comment.comment_text}</Linkify>
       </p>
 
       <div className="comment-meta">
@@ -95,7 +96,7 @@ const CommentBox = ({ comment }: CommentBoxProps) => {
               comment.comment_replies?.map(comment => {
                 return (
                   <Fragment key={comment.comment_id}>
-                    <CommentBox comment={comment} />
+                    <CommentBox comment={comment} onTimestampClick={onTimestampClick} />
                   </Fragment>
                 );
               })}

--- a/frontend/src/components/Linkify.tsx
+++ b/frontend/src/components/Linkify.tsx
@@ -3,17 +3,57 @@ import DOMPurify from 'dompurify';
 type LinkifyProps = {
   children: string;
   ignoreLineBreak?: boolean;
+  onTimestampClick?: (seconds: number) => void;
 };
 
 // source: https://www.js-craft.io/blog/react-detect-url-text-convert-link/
-const Linkify = ({ children, ignoreLineBreak = false }: LinkifyProps) => {
+const Linkify = ({ children, ignoreLineBreak = false, onTimestampClick }: LinkifyProps) => {
   const isUrl = (word: string) => {
     const urlPattern = /(https?:\/\/[^\s]+)/g;
     return word.match(urlPattern);
   };
 
+  const isTimestamp = (word: string) => {
+    const timestampPattern = /^(\d{1,}:)?(\d{1,2}):(\d{1,2})$/;
+    return word.match(timestampPattern);
+  };
+
+  const parseTimestamp = (timestamp: string): number => {
+    const parts = timestamp.split(':').map(part => parseInt(part, 10));
+
+    if (parts.length === 2) {
+      // MM:SS format
+      const [minutes, seconds] = parts;
+      return minutes * 60 + seconds;
+    } else if (parts.length === 3) {
+      // HH:MM:SS format
+      const [hours, minutes, seconds] = parts;
+      return hours * 3600 + minutes * 60 + seconds;
+    }
+
+    return 0;
+  };
+
   const addMarkup = (word: string) => {
-    return isUrl(word) ? `<a href="${word}">${word}</a>` : word;
+    if (isUrl(word)) {
+      return `<a href="${word}" rel="noopener noreferrer" target="_blank">${word}</a>`;
+    } else if (isTimestamp(word) && onTimestampClick) {
+      const seconds = parseTimestamp(word);
+      return `<span class="timestamp-link" data-timestamp="${seconds}">${word}</span>`;
+    }
+
+    return word;
+  };
+
+  const handleClick = (event: React.MouseEvent<HTMLSpanElement>) => {
+    const target = event.target as HTMLElement;
+    if (target.classList.contains('timestamp-link') && onTimestampClick) {
+      const timestamp = target.getAttribute('data-timestamp');
+      if (timestamp) {
+        const seconds = parseInt(timestamp, 10);
+        onTimestampClick(seconds);
+      }
+    }
   };
 
   let workingText = children;
@@ -26,9 +66,11 @@ const Linkify = ({ children, ignoreLineBreak = false }: LinkifyProps) => {
 
   const formatedWords = words.map(w => addMarkup(w));
 
-  const html = DOMPurify.sanitize(formatedWords.join(' '));
+  const html = DOMPurify.sanitize(formatedWords.join(' '), {
+    ADD_ATTR: ['target'],
+  });
 
-  return <span dangerouslySetInnerHTML={{ __html: html }} />;
+  return <span dangerouslySetInnerHTML={{ __html: html }} onClick={handleClick} />;
 };
 
 export default Linkify;

--- a/frontend/src/components/Linkify.tsx
+++ b/frontend/src/components/Linkify.tsx
@@ -25,7 +25,9 @@ const Linkify = ({ children, ignoreLineBreak = false, onTimestampClick }: Linkif
       // MM:SS format
       const [minutes, seconds] = parts;
       return minutes * 60 + seconds;
-    } else if (parts.length === 3) {
+    }
+
+    if (parts.length === 3) {
       // HH:MM:SS format
       const [hours, minutes, seconds] = parts;
       return hours * 3600 + minutes * 60 + seconds;
@@ -37,7 +39,9 @@ const Linkify = ({ children, ignoreLineBreak = false, onTimestampClick }: Linkif
   const addMarkup = (word: string) => {
     if (isUrl(word)) {
       return `<a href="${word}" rel="noopener noreferrer" target="_blank">${word}</a>`;
-    } else if (isTimestamp(word) && onTimestampClick) {
+    }
+
+    if (isTimestamp(word) && onTimestampClick) {
       const seconds = parseTimestamp(word);
       return `<span class="timestamp-link" data-timestamp="${seconds}">${word}</span>`;
     }

--- a/frontend/src/components/VideoPlayer.tsx
+++ b/frontend/src/components/VideoPlayer.tsx
@@ -112,6 +112,7 @@ type VideoPlayerProps = {
   onWatchStateChanged?: (status: boolean) => void;
   onVideoEnd?: () => void;
   seekToTimestamp?: number;
+  setSeekToTimestamp?: (timestamp: number | undefined) => void;
 };
 
 const VideoPlayer = ({
@@ -122,6 +123,7 @@ const VideoPlayer = ({
   onWatchStateChanged,
   onVideoEnd,
   seekToTimestamp,
+  setSeekToTimestamp,
 }: VideoPlayerProps) => {
   const videoRef = useRef<HTMLVideoElement | null>(null);
 
@@ -140,6 +142,8 @@ const VideoPlayer = ({
     if (videoRef.current.paused) {
       videoRef.current.play();
     }
+    if (setSeekToTimestamp) setSeekToTimestamp(undefined);
+    window.scroll(0, 0);
   }, [seekToTimestamp]);
 
   const [searchParams] = useSearchParams();

--- a/frontend/src/components/VideoPlayer.tsx
+++ b/frontend/src/components/VideoPlayer.tsx
@@ -111,6 +111,7 @@ type VideoPlayerProps = {
   autoplay?: boolean;
   onWatchStateChanged?: (status: boolean) => void;
   onVideoEnd?: () => void;
+  seekToTimestamp?: number;
 };
 
 const VideoPlayer = ({
@@ -120,8 +121,26 @@ const VideoPlayer = ({
   autoplay = false,
   onWatchStateChanged,
   onVideoEnd,
+  seekToTimestamp,
 }: VideoPlayerProps) => {
   const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  useEffect(() => {
+    if (seekToTimestamp === undefined || !videoRef.current) {
+      return;
+    }
+
+    const videoDuration = videoRef.current.duration;
+    if (isNaN(videoDuration) || seekToTimestamp > videoDuration) {
+      return;
+    }
+
+    videoRef.current.currentTime = seekToTimestamp;
+
+    if (videoRef.current.paused) {
+      videoRef.current.play();
+    }
+  }, [seekToTimestamp]);
 
   const [searchParams] = useSearchParams();
   const searchParamVideoProgress = searchParams.get('t');

--- a/frontend/src/pages/Video.tsx
+++ b/frontend/src/pages/Video.tsx
@@ -109,6 +109,7 @@ const Video = () => {
   const { userConfig } = useUserConfigStore();
 
   const [videoEnded, setVideoEnded] = useState(false);
+  const [seekToTimestamp, setSeekToTimestamp] = useState<number>();
   const [playlistAutoplay, setPlaylistAutoplay] = useState(
     localStorage.getItem('playlistAutoplay') === 'true',
   );
@@ -134,6 +135,13 @@ const Video = () => {
   const { data: videoPlaylistNavResponseData } = videoPlaylistNav ?? {};
   const { data: customPlaylistsResponseData } = customPlaylistsResponse ?? {};
   const { data: commentsResponseData } = commentsResponse ?? {};
+
+  const handleTimestampClick = (seconds: number) => {
+    setSeekToTimestamp(seconds);
+
+    // Reset timestamp to allow clicking again
+    setTimeout(() => setSeekToTimestamp(undefined), 500);
+  };
 
   useEffect(() => {
     (async () => {
@@ -224,6 +232,7 @@ const Video = () => {
         video={video}
         sponsorBlock={sponsorBlock}
         autoplay={playlistAutoplay}
+        seekToTimestamp={seekToTimestamp}
         onWatchStateChanged={() => {
           setRefreshVideoList(true);
         }}
@@ -488,7 +497,7 @@ const Video = () => {
               id={descriptionExpanded ? 'text-expand-expanded' : 'text-expand'}
               className="description-text"
             >
-              <Linkify>{video.description}</Linkify>
+              <Linkify onTimestampClick={handleTimestampClick}>{video.description}</Linkify>
             </p>
 
             <Button
@@ -601,7 +610,7 @@ const Video = () => {
               {comments?.map(comment => {
                 return (
                   <Fragment key={comment.comment_id}>
-                    <CommentBox comment={comment} />
+                    <CommentBox comment={comment} onTimestampClick={handleTimestampClick} />
                   </Fragment>
                 );
               })}

--- a/frontend/src/pages/Video.tsx
+++ b/frontend/src/pages/Video.tsx
@@ -138,9 +138,6 @@ const Video = () => {
 
   const handleTimestampClick = (seconds: number) => {
     setSeekToTimestamp(seconds);
-
-    // Reset timestamp to allow clicking again
-    setTimeout(() => setSeekToTimestamp(undefined), 500);
   };
 
   useEffect(() => {
@@ -233,6 +230,7 @@ const Video = () => {
         sponsorBlock={sponsorBlock}
         autoplay={playlistAutoplay}
         seekToTimestamp={seekToTimestamp}
+        setSeekToTimestamp={setSeekToTimestamp}
         onWatchStateChanged={() => {
           setRefreshVideoList(true);
         }}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -959,6 +959,12 @@ video:-webkit-full-screen {
   filter: var(--img-filter-error);
 }
 
+.timestamp-link {
+  color: var(--accent-font-light);
+  cursor: pointer;
+  font-weight: bold;
+}
+
 /* multi search page */
 .multi-search-box {
   padding-right: 20px;


### PR DESCRIPTION
I added clickable timestamps as described in #677 and known from YouTube.

Timestamps in video descriptions and comments (like 1:23, 12:34, or 1:23:45) are now clickable links that will jump directly to that moment in the video.

I also added `target="_blank"` to all links in the video description and comments so the video won't be interrupted.
