### PR TITLE
Add option to update yt-dlp on restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ All environment variables are explained in detail in the docs [here](https://doc
 | ELASTIC_USER | Change the default ElasticSearch user | Optional |
 | TA_LDAP | Configure TA to use LDAP Authentication | [Read more](https://docs.tubearchivist.com/configuration/ldap/) |
 | DISABLE_STATIC_AUTH | Remove authentication from media files, (Google Cast...) | [Read more](https://docs.tubearchivist.com/installation/env-vars/#disable_static_auth) |
+| TA_AUTO_UPDATE_YTDLP | Configure TA to automatically install the latest yt-dlp on container start | Optional |
 | DJANGO_DEBUG | Return additional error messages, for debug only | Optional |
 | TA_LOGIN_AUTH_MODE | Configure the order of login authentication backends (Default: single) | Optional |
 

--- a/docker_assets/run.sh
+++ b/docker_assets/run.sh
@@ -9,9 +9,13 @@ else
   LOGLEVEL="INFO"
 fi
 
-if [ "${TA_AUTO_UPDATE_YTDLP,,}" = "true" ]; then
+# update yt-dlp if needed
+if [[ "${TA_AUTO_UPDATE_YTDLP,,}" =~ ^(release|nightly)$ ]]; then
     echo "Updating yt-dlp..."
-    python -m pip install -U yt-dlp
+    preflag=$([[ "${TA_AUTO_UPDATE_YTDLP,,}" == "nightly" ]] && echo "--pre" || echo "")
+    python -m pip install --target=/root/.local/bin --upgrade $preflag "yt-dlp[default]" || {
+        echo "yt-dlp update failed"
+    }
 fi
 
 # stop on pending manual migration

--- a/docker_assets/run.sh
+++ b/docker_assets/run.sh
@@ -9,6 +9,11 @@ else
   LOGLEVEL="INFO"
 fi
 
+if [ "${TA_AUTO_UPDATE_YTDLP,,}" = "true" ]; then
+    echo "Updating yt-dlp..."
+    python -m pip install -U yt-dlp
+fi
+
 # stop on pending manual migration
 python manage.py ta_stop_on_error
 


### PR DESCRIPTION
The majority of times that I experience an issue where a video does not download, the solution is to upgrade the version of `yt-dlp` running in the container. It would be nice if that were more convenient.

I added a new env var to have the container try to install a newer version on start. I'm not married to this approach but I thought it would be a good way to get the conversation started. Two cons to this approach are that it requires manual intervention and that there is no compatibility guarantee with the new version of `yt-dlp`. However, these are also true of my manual workflow today. Let me know what you think. Thanks!