### PR TITLE
Delete channels with no videos

### DIFF
--- a/frontend/src/api/actions/deleteAllEmptyChannels.ts
+++ b/frontend/src/api/actions/deleteAllEmptyChannels.ts
@@ -1,0 +1,48 @@
+import APIClient from '../../functions/APIClient';
+
+const deleteAllEmptyChannels = async () => {
+  const allChannelIds: string[] = [];
+  const emptyChannels: string[] = [];
+
+  let nextCursor: string | null = '';
+
+  // Grab all channel IDs
+  while (nextCursor != null) {
+    const channels: any = await APIClient(
+      `/api/channel/${nextCursor ? '?page=' + nextCursor : ''}`,
+      {
+        method: 'GET',
+      },
+    );
+
+    const ids = channels?.data?.data.map((channel: any) => channel?.channel_id);
+
+    allChannelIds.push(...ids);
+
+    if (channels?.data?.paginate?.next_pages.length > 0) {
+      nextCursor = channels?.data?.paginate?.next_pages[0];
+    } else {
+      nextCursor = null;
+    }
+  }
+
+  // Check each channel to see if it has any videos
+  for (const channelId of allChannelIds) {
+    const channel: any = await APIClient(`/api/video/?channel=${channelId}&type=videos`, {
+      method: 'GET',
+    });
+
+    if (channel?.data?.data.length < 1) {
+      emptyChannels.push(channelId);
+    }
+  }
+
+  // Delete each empty channel
+  for (const channelId of emptyChannels) {
+    await APIClient(`/api/channel/${channelId}/`, {
+      method: 'DELETE',
+    });
+  }
+};
+
+export default deleteAllEmptyChannels;

--- a/frontend/src/pages/SettingsActions.tsx
+++ b/frontend/src/pages/SettingsActions.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import loadBackupList, { BackupListType } from '../api/loader/loadBackupList';
 import SettingsNavigation from '../components/SettingsNavigation';
 import deleteDownloadQueueByFilter from '../api/actions/deleteDownloadQueueByFilter';
+import deleteAllEmptyChannels from '../api/actions/deleteAllEmptyChannels';
 import updateTaskByName from '../api/actions/updateTaskByName';
 import queueBackup from '../api/actions/queueBackup';
 import restoreBackup from '../api/actions/restoreBackup';
@@ -12,6 +13,7 @@ import { ApiResponseType } from '../functions/APIClient';
 const SettingsActions = () => {
   const [deleteIgnored, setDeleteIgnored] = useState(false);
   const [deletePending, setDeletePending] = useState(false);
+  const [deleteEmptyChannels, setDeleteEmptyChannels] = useState(false);
   const [processingImports, setProcessingImports] = useState(false);
   const [reEmbed, setReEmbed] = useState(false);
   const [backupStarted, setBackupStarted] = useState(false);
@@ -43,6 +45,7 @@ const SettingsActions = () => {
           update={
             deleteIgnored ||
             deletePending ||
+            deleteEmptyChannels ||
             processingImports ||
             reEmbed ||
             backupStarted ||
@@ -52,6 +55,7 @@ const SettingsActions = () => {
           setShouldRefresh={() => {
             setDeleteIgnored(false);
             setDeletePending(false);
+            setDeleteEmptyChannels(false);
             setProcessingImports(false);
             setReEmbed(false);
             setBackupStarted(false);
@@ -85,6 +89,21 @@ const SettingsActions = () => {
               onClick={async () => {
                 await deleteDownloadQueueByFilter('pending');
                 setDeletePending(true);
+              }}
+            />
+          )}
+        </div>
+        <div className="settings-group">
+          <h2>Delete empty channels</h2>
+          <p>Delete indexed channels that have no videos published.</p>
+          {deleteEmptyChannels && <p>Deleting empty channels...</p>}
+          {!deleteEmptyChannels && (
+            <Button
+              label="Delete empty channels"
+              title="Delete empty channels that are indexed"
+              onClick={async () => {
+                await deleteAllEmptyChannels();
+                setDeleteEmptyChannels(true);
               }}
             />
           )}


### PR DESCRIPTION
This pull request partially completes issue #630 . It adds an option under `Settings > Actions` to delete channels that have no videos published. I'm not sure if it also checks against playlist videos, shorts and livestreams but I think this is a good start.

I did add `:any` types to API requests because API responses are "untyped", but only the eslint pre-commit hook was partially skipped. All the other API endpoints called from the frontend use one function, so this should probably be done by adding another endpoint to the API (instead of sending lots of requests). I'm not familiar with the backend or ES so I did it all from the frontend.