### PR TITLE
Add test notification button

### DIFF
--- a/backend/task/serializers.py
+++ b/backend/task/serializers.py
@@ -91,3 +91,12 @@ class TaskNotificationPostSerializer(serializers.Serializer):
 
     task_name = serializers.ChoiceField(choices=list(TASK_CONFIG))
     url = serializers.CharField(required=False)
+
+
+class TaskNotificationTestSerializer(serializers.Serializer):
+    """serialize task notification test POST"""
+
+    url = serializers.CharField()
+    task_name = serializers.ChoiceField(
+        choices=list(TASK_CONFIG), required=False
+    )

--- a/backend/task/urls.py
+++ b/backend/task/urls.py
@@ -34,4 +34,9 @@ urlpatterns = [
         views.ScheduleNotification.as_view(),
         name="api-schedule-notification",
     ),
+    path(
+        "notification/test/",
+        views.NotificationTestView.as_view(),
+        name="api-schedule-notification-test",
+    ),
 ]

--- a/backend/task/views.py
+++ b/backend/task/views.py
@@ -360,6 +360,63 @@ class NotificationTestView(ApiBaseView):
             ),
         },
     )
+    def _setup_apprise_logging(self):
+        """Setup logging capture for apprise"""
+        import io
+        import logging
+
+        log_capture = io.StringIO()
+        handler = logging.StreamHandler(log_capture)
+        formatter = logging.Formatter("%(levelname)s: %(message)s")
+        handler.setFormatter(formatter)
+        loggers_to_capture = ["apprise", "requests", "urllib3"]
+        original_levels = {}
+
+        for logger_name in loggers_to_capture:
+            logger = logging.getLogger(logger_name)
+            original_levels[logger_name] = logger.level
+            logger.addHandler(handler)
+            logger.setLevel(logging.DEBUG)
+            logger.propagate = True
+
+        return log_capture, handler, loggers_to_capture, original_levels
+
+    def _cleanup_apprise_logging(
+        self, handler, loggers_to_capture, original_levels
+    ):
+        """Cleanup apprise logging setup"""
+        import logging
+
+        for logger_name in loggers_to_capture:
+            logger = logging.getLogger(logger_name)
+            logger.removeHandler(handler)
+            logger.setLevel(original_levels[logger_name])
+
+    def _parse_apprise_error_message(self, log_output):
+        """Parse log output from apprise for detailed error information"""
+        error_msg = "Notification failed"
+        if log_output:
+            lines = log_output.strip().split("\n")
+            error_lines = [
+                line
+                for line in lines
+                if any(
+                    level in line for level in ["ERROR", "WARNING", "CRITICAL"]
+                )
+            ]
+            if error_lines:
+                error_msg = error_lines[-1]
+                if ":" in error_msg:
+                    error_msg = error_msg.split(":", 1)[-1].strip()
+            else:
+                error_msg = f"Notification failed - {log_output.strip()}"
+        else:
+            error_msg = (
+                "Notification failed - check URL format, "
+                "credentials, and network connectivity"
+            )
+        return error_msg
+
     def post(self, request):
         """test notification"""
         import apprise
@@ -371,21 +428,52 @@ class NotificationTestView(ApiBaseView):
         url = validated_data["url"]
         task_name = validated_data.get("task_name", "manual_test")
 
-        apobj = apprise.Apprise()
-        if not apobj.add(url):
-            error = ErrorResponseSerializer(
-                {"error": "invalid notification URL"}
-            )
-            return Response(error.data, status=400)
-
-        title = f"[TA] {task_name} process ended with SUCCESS"
-        body = "This is a test notification. Task completed successfully."
+        # Setup logging
+        log_capture, handler, loggers_to_capture, original_levels = (
+            self._setup_apprise_logging()
+        )
 
         try:
+            apobj = apprise.Apprise()
+
+            if not apobj.add(url):
+                log_output = log_capture.getvalue()
+                error_msg = f"Invalid notification URL format: {url}"
+                if log_output:
+                    error_msg += f" - Details: {log_output.strip()}"
+                return Response(
+                    {"success": False, "message": error_msg}, status=400
+                )
+
+            title = f"[TA] {task_name} process ended with SUCCESS"
+            body = "This is a test notification. Task completed successfully."
+
             result = apobj.notify(body=body, title=title)
+            log_output = log_capture.getvalue()
+
+            if result:
+                response_data = {
+                    "success": True,
+                    "message": "Test notification sent successfully",
+                }
+                if log_output:
+                    response_data["debug_info"] = log_output.strip()
+                return Response(response_data)
+
+            error_msg = self._parse_apprise_error_message(log_output)
             return Response(
-                {"success": result, "message": "Test notification sent"}
+                {"success": False, "message": error_msg}, status=400
             )
+
         except Exception as err:
-            error = ErrorResponseSerializer({"error": str(err)})
-            return Response(error.data, status=400)
+            log_output = log_capture.getvalue()
+            error_msg = f"Notification error: {str(err)}"
+            if log_output:
+                error_msg += f" - Log output: {log_output.strip()}"
+            return Response(
+                {"success": False, "message": error_msg}, status=400
+            )
+        finally:
+            self._cleanup_apprise_logging(
+                handler, loggers_to_capture, original_levels
+            )

--- a/frontend/src/api/actions/testAppriseNotificationUrl.ts
+++ b/frontend/src/api/actions/testAppriseNotificationUrl.ts
@@ -1,0 +1,16 @@
+import APIClient from '../../functions/APIClient';
+import { AppriseTaskNameType } from './createAppriseNotificationUrl';
+
+export type TestNotificationResponseType = {
+  success: boolean;
+  message: string;
+};
+
+const testAppriseNotificationUrl = async (taskName: AppriseTaskNameType, url: string) => {
+  return APIClient<TestNotificationResponseType>('/api/task/notification/test/', {
+    method: 'POST',
+    body: { task_name: taskName, url },
+  });
+};
+
+export default testAppriseNotificationUrl;

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -9,6 +9,7 @@ export interface ButtonProps {
   children?: string | ReactNode | ReactNode[];
   value?: string;
   title?: string;
+  disabled?: boolean;
   onClick?: () => void;
 }
 
@@ -21,6 +22,7 @@ const Button = ({
   children,
   value,
   title,
+  disabled,
   onClick,
 }: ButtonProps) => {
   return (
@@ -31,6 +33,7 @@ const Button = ({
       type={type}
       value={value}
       title={title}
+      disabled={disabled}
       onClick={onClick}
     >
       {label}

--- a/frontend/src/pages/SettingsScheduling.tsx
+++ b/frontend/src/pages/SettingsScheduling.tsx
@@ -65,7 +65,10 @@ const SettingsScheduling = () => {
   const [downloadPendingError, setDownloadPendingError] = useState<string | null>(null);
   const [thumnailCheckError, setThumnailCheckError] = useState<string | null>(null);
   const [zipBackupError, setZipBackupError] = useState<string | null>(null);
-  const [testNotificationMessage, setTestNotificationMessage] = useState<string | null>(null);
+  const [testNotificationMessage, setTestNotificationMessage] = useState<{
+    message: string;
+    success: boolean;
+  } | null>(null);
 
   const { data: appriseNotificationData } = appriseNotification ?? {};
 
@@ -576,6 +579,7 @@ const SettingsScheduling = () => {
               <div className="button-box">
                 <Button
                   label="Save"
+                  disabled={!notificationUrl || !notificationTask}
                   onClick={async () => {
                     await createAppriseNotificationUrl(
                       notificationTask as AppriseTaskNameType,
@@ -588,6 +592,7 @@ const SettingsScheduling = () => {
 
                 <Button
                   label="Test"
+                  disabled={!notificationUrl || !notificationTask}
                   onClick={async () => {
                     setTestNotificationMessage(null);
                     try {
@@ -597,20 +602,25 @@ const SettingsScheduling = () => {
                           notificationUrl || '',
                         );
                       if (response.data?.success) {
-                        setTestNotificationMessage(response.data.message);
+                        setTestNotificationMessage({
+                          message: response.data.message,
+                          success: true,
+                        });
                       } else {
-                        setTestNotificationMessage(
-                          response.data?.message || 'Test notification failed',
-                        );
+                        setTestNotificationMessage({
+                          message: response.data?.message || 'Test notification failed',
+                          success: true,
+                        });
                       }
                     } catch (error) {
                       const apiError = error as ApiError;
                       if (apiError.status && apiError.message) {
-                        setTestNotificationMessage(apiError.message);
+                        setTestNotificationMessage({ message: apiError.message, success: false });
                       } else {
-                        setTestNotificationMessage(
-                          'An unexpected error occurred while testing notification.',
-                        );
+                        setTestNotificationMessage({
+                          message: 'An unexpected error occurred while testing notification.',
+                          success: false,
+                        });
                       }
                     }
                     setRefresh(true);
@@ -618,8 +628,11 @@ const SettingsScheduling = () => {
                 />
               </div>
               {testNotificationMessage && (
-                <div className="danger-zone" style={{ marginTop: '10px' }}>
-                  {testNotificationMessage}
+                <div
+                  className={!testNotificationMessage.success ? 'danger-zone' : ''}
+                  style={{ margin: '10px 5px' }}
+                >
+                  <p>{testNotificationMessage.message}</p>
                 </div>
               )}
             </div>

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -133,6 +133,17 @@ button:hover {
   color: var(--main-bg);
 }
 
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+button:disabled:hover {
+  background-color: var(--accent-font-dark);
+  transform: none;
+  color: #ffffff;
+}
+
 .video-item.table {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
While I have been trying to configure a webhook to get Plex to rescan my Tubearchivist when a download completes, I keep having to download an actual video to test. It has been a lot of trial and error unfortunately.

So, to speed up my configuration, I have added a test button so you can see any errors without having to actually trigger the event.

Apprise does not return these errors directly. Instead they expose out a [log capture](https://github.com/caronc/apprise/wiki/Development_LogCapture) for this purpose. It seems a bit heavy handed to me but this seems the be the way people are doing this sort of thing from Apprise.