### PR TITLE
Configurable LDAP user promotion to superuser or staff

### DIFF
--- a/backend/config/fwd_auth_settings.py
+++ b/backend/config/fwd_auth_settings.py
@@ -1,0 +1,6 @@
+from os import environ
+
+TA_AUTH_PROXY_USERNAME_HEADER = (
+    environ.get("TA_AUTH_PROXY_USERNAME_HEADER") or "HTTP_REMOTE_USER"
+)
+TA_AUTH_PROXY_LOGOUT_URL = environ.get("TA_AUTH_PROXY_LOGOUT_URL")

--- a/backend/config/ldap_settings.py
+++ b/backend/config/ldap_settings.py
@@ -1,4 +1,5 @@
 from os import environ
+
 import ldap
 from django_auth_ldap.config import LDAPSearch
 
@@ -73,3 +74,53 @@ if bool(environ.get("TA_LDAP_DISABLE_CERT_CHECK")):
     AUTH_LDAP_GLOBAL_OPTIONS = {
         ldap.OPT_X_TLS_REQUIRE_CERT: ldap.OPT_X_TLS_NEVER,
     }
+
+# Promote specific usernames to staff or superuser permission levels
+_ldap_superuser_username_config = (
+    environ.get("TA_LDAP_PROMOTE_USERNAMES_TO_SUPERUSER") or ""
+)
+_ldap_superuser_usernames = []
+if _ldap_superuser_username_config:
+    _ldap_superuser_usernames = [
+        u.strip() for u in _ldap_superuser_username_config.split(",")
+    ]
+
+_ldap_staff_username_config = (
+    environ.get("TA_LDAP_PROMOTE_USERNAMES_TO_STAFF") or ""
+)
+_ldap_staff_usernames = []
+if _ldap_staff_username_config:
+    _ldap_staff_usernames = [
+        u.strip() for u in _ldap_staff_username_config.split(",")
+    ]
+
+if _ldap_staff_usernames or _ldap_superuser_usernames:
+    import django_auth_ldap.backend
+
+    if environ.get("DJANGO_LOG_LEVEL"):
+        print(
+            "LDAP Users in this list will be promoted to staff: "
+            + f"{_ldap_staff_usernames}"
+        )
+        print(
+            "LDAP Users in this list will be promoted to superuser:"
+            + f"{_ldap_superuser_usernames}"
+        )
+
+    def create_user(sender, user=None, ldap_user=None, **kwargs):
+        if environ.get("DJANGO_LOG_LEVEL"):
+            print(
+                f"LDAP user {user.ldap_username} (dn={ldap_user.dn}) "
+                + "logged in, checking for privileges to add"
+            )
+        if user.ldap_username in _ldap_superuser_usernames and not (
+            user.is_superuser and user.is_staff
+        ):
+            user.is_staff = True
+            user.is_superuser = True
+            user.save()
+        elif user.ldap_username in _ldap_staff_usernames and not user.is_staff:
+            user.is_staff = True
+            user.save()
+
+    django_auth_ldap.backend.populate_user.connect(create_user)

--- a/backend/config/ldap_settings.py
+++ b/backend/config/ldap_settings.py
@@ -1,0 +1,75 @@
+from os import environ
+import ldap
+from django_auth_ldap.config import LDAPSearch
+
+AUTH_LDAP_SERVER_URI = environ.get("TA_LDAP_SERVER_URI")
+
+AUTH_LDAP_BIND_DN = environ.get("TA_LDAP_BIND_DN")
+
+AUTH_LDAP_BIND_PASSWORD = environ.get("TA_LDAP_BIND_PASSWORD")
+
+"""
+Given Names are *_technically_* different from Personal names, as people
+who change their names have different given names and personal names,
+and they go by personal names. Additionally, "LastName" is actually
+incorrect for many cultures, such as Korea, where the
+family name comes first, and the personal name comes last.
+
+But we all know people are going to try to guess at these, so still want
+to include names that people will guess, hence using first/last as well.
+"""
+
+AUTH_LDAP_USER_ATTR_MAP_USERNAME = (
+    environ.get("TA_LDAP_USER_ATTR_MAP_USERNAME")
+    or environ.get("TA_LDAP_USER_ATTR_MAP_UID")
+    or "uid"
+)
+
+AUTH_LDAP_USER_ATTR_MAP_PERSONALNAME = (
+    environ.get("TA_LDAP_USER_ATTR_MAP_PERSONALNAME")
+    or environ.get("TA_LDAP_USER_ATTR_MAP_FIRSTNAME")
+    or environ.get("TA_LDAP_USER_ATTR_MAP_GIVENNAME")
+    or "givenName"
+)
+
+AUTH_LDAP_USER_ATTR_MAP_SURNAME = (
+    environ.get("TA_LDAP_USER_ATTR_MAP_SURNAME")
+    or environ.get("TA_LDAP_USER_ATTR_MAP_LASTNAME")
+    or environ.get("TA_LDAP_USER_ATTR_MAP_FAMILYNAME")
+    or "sn"
+)
+
+AUTH_LDAP_USER_ATTR_MAP_EMAIL = (
+    environ.get("TA_LDAP_USER_ATTR_MAP_EMAIL")
+    or environ.get("TA_LDAP_USER_ATTR_MAP_MAIL")
+    or "mail"
+)
+
+AUTH_LDAP_USER_BASE = environ.get("TA_LDAP_USER_BASE")
+
+AUTH_LDAP_USER_FILTER = environ.get("TA_LDAP_USER_FILTER")
+
+# pylint: disable=no-member
+AUTH_LDAP_USER_SEARCH = LDAPSearch(
+    AUTH_LDAP_USER_BASE,
+    ldap.SCOPE_SUBTREE,
+    "(&("
+    + AUTH_LDAP_USER_ATTR_MAP_USERNAME
+    + "=%(user)s)"
+    + AUTH_LDAP_USER_FILTER
+    + ")",
+)
+
+AUTH_LDAP_USER_ATTR_MAP = {
+    "username": AUTH_LDAP_USER_ATTR_MAP_USERNAME,
+    "first_name": AUTH_LDAP_USER_ATTR_MAP_PERSONALNAME,
+    "last_name": AUTH_LDAP_USER_ATTR_MAP_SURNAME,
+    "email": AUTH_LDAP_USER_ATTR_MAP_EMAIL,
+}
+
+if bool(environ.get("TA_LDAP_DISABLE_CERT_CHECK")):
+    # pylint: disable=global-at-module-level
+    global AUTH_LDAP_GLOBAL_OPTIONS
+    AUTH_LDAP_GLOBAL_OPTIONS = {
+        ldap.OPT_X_TLS_REQUIRE_CERT: ldap.OPT_X_TLS_NEVER,
+    }

--- a/backend/config/management/commands/ta_envcheck.py
+++ b/backend/config/management/commands/ta_envcheck.py
@@ -81,6 +81,7 @@ class Command(BaseCommand):
         """run all commands"""
         self.stdout.write(LOGO)
         self.stdout.write(TOPIC)
+        self._additional_vars_expectations()
         self._expected_vars()
         self._unexpected_vars()
         self._elastic_user_overwrite()
@@ -88,6 +89,50 @@ class Command(BaseCommand):
         self._ta_backend_port_overwrite()
         self._disable_static_auth()
         self._create_superuser()
+
+    def _additional_vars_expectations(self):
+        """conditionally add additional expected variables"""
+        ldap_required_env = [
+            "TA_LDAP_SERVER_URI",
+            "TA_LDAP_BIND_DN",
+            "TA_LDAP_BIND_PASSWORD",
+            "TA_LDAP_USER_BASE",
+            "TA_LDAP_USER_FILTER",
+        ]
+        _login_auth_mode = (
+            os.environ.get("TA_LOGIN_AUTH_MODE") or "single"
+        ).casefold()
+        if _login_auth_mode == "local":
+            UNEXPECTED_ENV_VARS["TA_LDAP"] = (
+                "TA_LDAP is not valid with current auth mode"
+            )
+            UNEXPECTED_ENV_VARS["TA_ENABLE_AUTH_PROXY"] = (
+                "TA_ENABLE_AUTH_PROXY is not valid with current auth mode"
+            )
+        elif _login_auth_mode == "ldap":
+            EXPECTED_ENV_VARS.extend(ldap_required_env)
+            UNEXPECTED_ENV_VARS["TA_ENABLE_AUTH_PROXY"] = (
+                "TA_ENABLE_AUTH_PROXY is not valid with current auth mode"
+            )
+        elif _login_auth_mode == "forwardauth":
+            UNEXPECTED_ENV_VARS["TA_LDAP"] = (
+                "TA_LDAP is not valid with current auth mode"
+            )
+        elif _login_auth_mode == "ldap_local":
+            EXPECTED_ENV_VARS.extend(ldap_required_env)
+            UNEXPECTED_ENV_VARS["TA_ENABLE_AUTH_PROXY"] = (
+                "TA_ENABLE_AUTH_PROXY is not valid with current auth mode"
+            )
+        else:
+            if bool(os.environ.get("TA_LDAP")):
+                EXPECTED_ENV_VARS.extend(ldap_required_env)
+                UNEXPECTED_ENV_VARS["TA_ENABLE_AUTH_PROXY"] = (
+                    "TA_ENABLE_AUTH_PROXY is not valid with current auth mode"
+                )
+            if bool(os.environ.get("TA_ENABLE_AUTH_PROXY")):
+                UNEXPECTED_ENV_VARS["TA_LDAP"] = (
+                    "TA_LDAP is not valid with current auth mode"
+                )
 
     def _expected_vars(self):
         """check if expected env vars are set"""

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -236,3 +236,29 @@ SPECTACULAR_SETTINGS = {
     "VERSION": TA_VERSION,
     "SERVE_INCLUDE_SCHEMA": False,
 }
+
+# Optionally enable messy debug logging for troubleshooting purposes.
+if (environ.get("DJANGO_LOG_LEVEL")) == "DEBUG":
+    LOGGING = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+            },
+        },
+        "root": {
+            "handlers": ["console"],
+            "level": "DEBUG",
+        },
+        "loggers": {
+            "": {
+                "handlers": ["console"],
+                "level": "DEBUG",
+            },
+            "django": {
+                "handlers": ["console"],
+                "level": "DEBUG",
+            },
+        },
+    }


### PR DESCRIPTION
### Pull Request Description

**Overview:**
This pull request refactors settings for LDAP and forward authentication settings in the Django backend. It adds two new files, `fwd_auth_settings.py` and `ldap_settings.py`, to manage authentication-related environment variables and settings based on conditional imports. Additionally, it updates the existing environment check validat to include expectations for the authentication configurations.

**Changes Made:**

1. **New File: ```fwd_auth_settings.py```**
   - Moved forward-auth settings from main settings.py

2. **New File: ```ldap_settings.py```**
   - Moved LDAP settings from main settings.py
   - Defines various LDAP-related configurations, including:
   - Conditional promotion of specific usernames to staff or superuser levels, configured using new environment variables:
      - TA_LDAP_PROMOTE_USERNAMES_TO_SUPERUSER allows a comma-separated list of usernames which will be given staff and superuser permission
      - TA_LDAP_PROMOTE_USERNAMES_TO_STAFF allows a comma-separated list of usernames which will be given only staff permission

3. **Updates to ```ta_envcheck.py```**
   - Added a method ```_additional_vars_expectations()``` to check for the presence of required LDAP environment variables based on the current authentication mode.
   - Adjusts expected and unexpected environment variable checks based on the selected authentication mode.

4. **Modifications to ```settings.py```**
   - Removed the inline LDAP configuration and instead imported settings from ```ldap_settings.py``` when LDAP authentication is enabled.
   - Similarly, imports from ```fwd_auth_settings.py``` when forward authentication is enabled.
   - Fix for edge case where `TA_LOGIN_AUTH_MODE` was set to use LDAP, but `TA_LDAP` was not set.

