### PR TITLE
Get all sponsorblock segment types

### DIFF
--- a/frontend/src/components/VideoPlayer.tsx
+++ b/frontend/src/components/VideoPlayer.tsx
@@ -70,9 +70,11 @@ const handleTimeUpdate =
 
     if (sponsorBlock && sponsorBlock.segments) {
       sponsorBlock.segments.forEach((segment: SponsorBlockSegmentType) => {
+        const actionType = segment.actionType;
+        const doSkip = (actionType == 'skip');
         const [from, to] = segment.segment;
 
-        if (currentTime >= from && currentTime <= from + 0.3) {
+        if (doSkip && currentTime >= from && currentTime <= from + 0.3) {
           videoTag.currentTarget.currentTime = to;
 
           setSponsorSegmentSkipped?.((segments: SponsorSegmentsSkippedType) => {


### PR DESCRIPTION
Thank you for the excellent work on this project.
- This PR extends the sponsorblock query to store all types of segment
- The existing behaviour of skipping only `sponsor` segments is preserved
- No new UI options are required to be implemented

*There is an element of self-interest here! I'm running this variant for my main server.*