### PR TITLE
Disable login button while login processes is happening

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -14,6 +14,7 @@ const Login = () => {
   const [password, setPassword] = useState('');
   const [saveLogin, setSaveLogin] = useState(false);
   const [waitingForBackend, setWaitingForBackend] = useState(false);
+  const [loggingIn, setLoggingIn] = useState(false);
   const [waitedCount, setWaitedCount] = useState(0);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -25,17 +26,15 @@ const Login = () => {
     }
 
     setErrorMessage(null);
-
+    setLoggingIn(true);
     const loginResponse = await signIn(username, password, saveLogin);
-
     const signedIn = loginResponse.status === 204;
-
     if (signedIn) {
       navigate(Routes.Home);
     } else {
       const data = await loginResponse.json();
       setErrorMessage(data?.error || 'Unknown Error');
-      navigate(Routes.Login);
+      setLoggingIn(false);
     }
   };
 
@@ -140,7 +139,7 @@ const Login = () => {
             </>
           )}
 
-          {!waitingForBackend && <Button label="Login" type="submit" />}
+          {!waitingForBackend && <Button label="Login" type="submit" disabled={loggingIn} />}
         </form>
 
         {waitedCount > 10 && (


### PR DESCRIPTION
I run tubearchivist on a pretty old synology and the login process can take a second or two. Just long enough to tempt me into clicking the button a second time.
