### PR TITLE
Unify not found messaging

### DIFF
--- a/frontend/src/components/ChannelList.tsx
+++ b/frontend/src/components/ChannelList.tsx
@@ -19,7 +19,7 @@ const ChannelList = ({ channelList, refreshChannelList }: ChannelListProps) => {
   const viewStyle = userConfig.view_style_channel;
 
   if (!channelList || channelList.length === 0) {
-    return <p>No channels found.</p>;
+    return <p>No channels found...</p>;
   }
 
   return (

--- a/frontend/src/components/ChannelList.tsx
+++ b/frontend/src/components/ChannelList.tsx
@@ -19,7 +19,7 @@ const ChannelList = ({ channelList, refreshChannelList }: ChannelListProps) => {
   const viewStyle = userConfig.view_style_channel;
 
   if (!channelList || channelList.length === 0) {
-    return <p>No channels found...</p>;
+    return <h2>No channels found...</h2>;
   }
 
   return (

--- a/frontend/src/components/ChannelList.tsx
+++ b/frontend/src/components/ChannelList.tsx
@@ -7,6 +7,7 @@ import FormattedNumber from './FormattedNumber';
 import Button from './Button';
 import ChannelIcon from './ChannelIcon';
 import ChannelBanner from './ChannelBanner';
+import LoadingIndicator from './LoadingIndicator';
 import { useUserConfigStore } from '../stores/UserConfigStore';
 
 type ChannelListProps = {
@@ -18,7 +19,10 @@ const ChannelList = ({ channelList, refreshChannelList }: ChannelListProps) => {
   const { userConfig } = useUserConfigStore();
   const viewStyle = userConfig.view_style_channel;
 
-  if (!channelList || channelList.length === 0) {
+  if (!channelList) {
+    return <LoadingIndicator />;
+  }
+  if (channelList.length === 0) {
     return <h2>No channels found...</h2>;
   }
 

--- a/frontend/src/components/PlaylistList.tsx
+++ b/frontend/src/components/PlaylistList.tsx
@@ -17,7 +17,7 @@ const PlaylistList = ({ playlistList, setRefresh }: PlaylistListProps) => {
   const viewStyle = userConfig.view_style_playlist;
 
   if (!playlistList || playlistList.length === 0) {
-    return <p>No playlists found.</p>;
+    return <p>No playlists found...</p>;
   }
 
   return (

--- a/frontend/src/components/PlaylistList.tsx
+++ b/frontend/src/components/PlaylistList.tsx
@@ -17,7 +17,7 @@ const PlaylistList = ({ playlistList, setRefresh }: PlaylistListProps) => {
   const viewStyle = userConfig.view_style_playlist;
 
   if (!playlistList || playlistList.length === 0) {
-    return <p>No playlists found...</p>;
+    return <h2>No playlists found...</h2>;
   }
 
   return (

--- a/frontend/src/components/PlaylistList.tsx
+++ b/frontend/src/components/PlaylistList.tsx
@@ -4,6 +4,7 @@ import updatePlaylistSubscription from '../api/actions/updatePlaylistSubscriptio
 import formatDate from '../functions/formatDates';
 import Button from './Button';
 import PlaylistThumbnail from './PlaylistThumbnail';
+import LoadingIndicator from './LoadingIndicator';
 import { useUserConfigStore } from '../stores/UserConfigStore';
 import { PlaylistType } from '../api/loader/loadPlaylistById';
 
@@ -16,7 +17,10 @@ const PlaylistList = ({ playlistList, setRefresh }: PlaylistListProps) => {
   const { userConfig } = useUserConfigStore();
   const viewStyle = userConfig.view_style_playlist;
 
-  if (!playlistList || playlistList.length === 0) {
+  if (!playlistList) {
+    return <LoadingIndicator />;
+  }
+  if (playlistList.length === 0) {
     return <h2>No playlists found...</h2>;
   }
 

--- a/frontend/src/components/VideoList.tsx
+++ b/frontend/src/components/VideoList.tsx
@@ -2,6 +2,7 @@ import { ViewStylesEnum, ViewStylesType } from '../configuration/constants/ViewS
 import { VideoType } from '../pages/Home';
 import VideoListItem from './VideoListItem';
 import VideoListItemTable from './VideoListItemTable';
+import LoadingIndicator from './LoadingIndicator';
 
 type VideoListProps = {
   videoList: VideoType[] | undefined;
@@ -18,7 +19,10 @@ const VideoList = ({
   showReorderButton = false,
   refreshVideoList,
 }: VideoListProps) => {
-  if (!videoList || videoList.length === 0) {
+  if (!videoList) {
+    return <LoadingIndicator />;
+  }
+  if (videoList.length === 0) {
     return <h2>No videos found...</h2>;
   }
 

--- a/frontend/src/components/VideoList.tsx
+++ b/frontend/src/components/VideoList.tsx
@@ -19,7 +19,7 @@ const VideoList = ({
   refreshVideoList,
 }: VideoListProps) => {
   if (!videoList || videoList.length === 0) {
-    return <p>No videos found.</p>;
+    return <p>No videos found...</p>;
   }
 
   if (viewStyle === ViewStylesEnum.Table) {

--- a/frontend/src/components/VideoList.tsx
+++ b/frontend/src/components/VideoList.tsx
@@ -19,7 +19,7 @@ const VideoList = ({
   refreshVideoList,
 }: VideoListProps) => {
   if (!videoList || videoList.length === 0) {
-    return <p>No videos found...</p>;
+    return <h2>No videos found...</h2>;
   }
 
   if (viewStyle === ViewStylesEnum.Table) {

--- a/frontend/src/pages/ChannelVideo.tsx
+++ b/frontend/src/pages/ChannelVideo.tsx
@@ -168,17 +168,13 @@ const ChannelVideo = ({ videoType }: ChannelVideoProps) => {
 
         <div className={`boxed-content ${gridView}`}>
           <div className={`video-list ${viewStyle} ${gridViewGrid}`}>
-            {!hasVideos && (
-              <>
-                <h2>No videos found...</h2>
-                <p>
-                  Try going to the <Link to={Routes.Downloads}>downloads page</Link> to start the
-                  scan and download tasks.
-                </p>
-              </>
-            )}
-
             <VideoList videoList={videoList} viewStyle={viewStyle} refreshVideoList={setRefresh} />
+            {!hasVideos && (
+              <p>
+                Try going to the <Link to={Routes.Downloads}>downloads page</Link> to start the
+                scan and download tasks.
+              </p>
+            )}
           </div>
         </div>
         {pagination && (

--- a/frontend/src/pages/ChannelVideo.tsx
+++ b/frontend/src/pages/ChannelVideo.tsx
@@ -171,8 +171,8 @@ const ChannelVideo = ({ videoType }: ChannelVideoProps) => {
             <VideoList videoList={videoList} viewStyle={viewStyle} refreshVideoList={setRefresh} />
             {!hasVideos && (
               <p>
-                Try going to the <Link to={Routes.Downloads}>downloads page</Link> to start the
-                scan and download tasks.
+                Try going to the <Link to={Routes.Downloads}>downloads page</Link> to start the scan
+                and download tasks.
               </p>
             )}
           </div>

--- a/frontend/src/pages/Channels.tsx
+++ b/frontend/src/pages/Channels.tsx
@@ -59,7 +59,6 @@ const Channels = () => {
 
   const channels = channelListResponseData?.data;
   const pagination = channelListResponseData?.paginate;
-  const hasChannels = channels?.length !== 0;
 
   const handleUserConfigUpdate = async (config: Partial<UserConfigType>) => {
     const updatedUserConfig = await updateUserConfig(config);
@@ -195,9 +194,7 @@ const Channels = () => {
         </div>
 
         <div className={`channel-list ${userConfig.view_style_channel}`}>
-          {!hasChannels && <h2>No channels found...</h2>}
-
-          {hasChannels && <ChannelList channelList={channels} refreshChannelList={setRefresh} />}
+          <ChannelList channelList={channels} refreshChannelList={setRefresh} />
         </div>
 
         {pagination && (

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -198,10 +198,10 @@ const Home = () => {
       <div className={`boxed-content ${gridView}`}>
         <div className={`video-list ${userConfig.view_style_home} ${gridViewGrid}`}>
           <VideoList
-              videoList={videoList}
-              viewStyle={userConfig.view_style_home}
-              refreshVideoList={setRefreshVideoList}
-            />
+            videoList={videoList}
+            viewStyle={userConfig.view_style_home}
+            refreshVideoList={setRefreshVideoList}
+          />
           {!hasVideos && (
             <p>
               If you've already added a channel or playlist, try going to the{' '}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -197,23 +197,17 @@ const Home = () => {
 
       <div className={`boxed-content ${gridView}`}>
         <div className={`video-list ${userConfig.view_style_home} ${gridViewGrid}`}>
-          {!hasVideos && (
-            <>
-              <h2>No videos found...</h2>
-              <p>
-                If you've already added a channel or playlist, try going to the{' '}
-                <Link to={Routes.Downloads}>downloads page</Link> to start the scan and download
-                tasks.
-              </p>
-            </>
-          )}
-
-          {hasVideos && (
-            <VideoList
+          <VideoList
               videoList={videoList}
               viewStyle={userConfig.view_style_home}
               refreshVideoList={setRefreshVideoList}
             />
+          {!hasVideos && (
+            <p>
+              If you've already added a channel or playlist, try going to the{' '}
+              <Link to={Routes.Downloads}>downloads page</Link> to start the scan and download
+              tasks.
+            </p>
           )}
         </div>
       </div>

--- a/frontend/src/pages/Playlist.tsx
+++ b/frontend/src/pages/Playlist.tsx
@@ -350,12 +350,12 @@ const Playlist = () => {
       <div className={`boxed-content ${gridView}`}>
         <div className={`video-list ${viewStyle} ${gridViewGrid}`}>
           <VideoList
-              videoList={videos}
-              viewStyle={viewStyle}
-              playlistId={playlistId}
-              showReorderButton={isCustomPlaylist}
-              refreshVideoList={setRefresh}
-            />
+            videoList={videos}
+            viewStyle={viewStyle}
+            playlistId={playlistId}
+            showReorderButton={isCustomPlaylist}
+            refreshVideoList={setRefresh}
+          />
           {videoInPlaylistCount === 0 && (
             <>
               {isCustomPlaylist && (

--- a/frontend/src/pages/Playlist.tsx
+++ b/frontend/src/pages/Playlist.tsx
@@ -349,16 +349,21 @@ const Playlist = () => {
 
       <div className={`boxed-content ${gridView}`}>
         <div className={`video-list ${viewStyle} ${gridViewGrid}`}>
+          <VideoList
+              videoList={videos}
+              viewStyle={viewStyle}
+              playlistId={playlistId}
+              showReorderButton={isCustomPlaylist}
+              refreshVideoList={setRefresh}
+            />
           {videoInPlaylistCount === 0 && (
             <>
-              <h2>No videos found...</h2>
               {isCustomPlaylist && (
                 <p>
                   Try going to the <a href="{% url 'home' %}">home page</a> to add videos to this
                   playlist.
                 </p>
               )}
-
               {!isCustomPlaylist && (
                 <p>
                   Try going to the <Link to={Routes.Downloads}>downloads page</Link> to start the
@@ -366,15 +371,6 @@ const Playlist = () => {
                 </p>
               )}
             </>
-          )}
-          {videoInPlaylistCount !== 0 && (
-            <VideoList
-              videoList={videos}
-              viewStyle={viewStyle}
-              playlistId={playlistId}
-              showReorderButton={isCustomPlaylist}
-              refreshVideoList={setRefresh}
-            />
           )}
         </div>
       </div>

--- a/frontend/src/pages/Playlists.tsx
+++ b/frontend/src/pages/Playlists.tsx
@@ -38,8 +38,6 @@ const Playlists = () => {
   const playlistList = playlistResponseData?.data;
   const pagination = playlistResponseData?.paginate;
 
-  const hasPlaylists = playlistResponseData?.data?.length !== 0;
-
   const viewStyle = userConfig.view_style_playlist;
   const showSubedOnly = userConfig.show_subed_only;
 
@@ -197,9 +195,7 @@ const Playlists = () => {
         </div>
 
         <div className={`playlist-list ${viewStyle}`}>
-          {!hasPlaylists && <h2>No playlists found...</h2>}
-
-          {hasPlaylists && <PlaylistList playlistList={playlistList} setRefresh={setRefresh} />}
+          <PlaylistList playlistList={playlistList} setRefresh={setRefresh} />
         </div>
       </div>
 


### PR DESCRIPTION
This pr cleans up some duplicate "No xxxxxs found" messaging and adds some loading indicators. The unstyled white message was coming from the inner list components and the bold green message was in each individual component that used the lists.

![twoerrors](https://github.com/user-attachments/assets/a0eb3f1d-a026-438b-a88c-23137175f248)
