### PR TITLE
Improvement :: Group imports in the `Channels.tsx` file

### DIFF
--- a/frontend/src/pages/Channels.tsx
+++ b/frontend/src/pages/Channels.tsx
@@ -1,22 +1,27 @@
-import { useOutletContext } from 'react-router-dom';
-import loadChannelList, { ChannelsListResponse } from '../api/loader/loadChannelList';
-import iconGridView from '/img/icon-gridview.svg';
-import iconListView from '/img/icon-listview.svg';
-import iconAdd from '/img/icon-add.svg';
-import iconFilter from '/img/icon-filter.svg';
 import { useEffect, useState } from 'react';
+import { useOutletContext } from 'react-router-dom';
+
+import loadChannelList, { ChannelsListResponse } from '../api/loader/loadChannelList';
+import updateBulkChannelSubscriptions from '../api/actions/updateBulkChannelSubscriptions';
+import updateUserConfig, { UserConfigType } from '../api/actions/updateUserConfig';
+import { ApiResponseType } from '../functions/APIClient';
+
+import { useUserConfigStore } from '../stores/UserConfigStore';
+import useIsAdmin from '../functions/useIsAdmin';
+
 import Pagination from '../components/Pagination';
-import { OutletContextType } from './Base';
 import ChannelList from '../components/ChannelList';
 import ScrollToTopOnNavigate from '../components/ScrollToTop';
 import Notifications from '../components/Notifications';
 import Button from '../components/Button';
-import updateBulkChannelSubscriptions from '../api/actions/updateBulkChannelSubscriptions';
-import useIsAdmin from '../functions/useIsAdmin';
-import { useUserConfigStore } from '../stores/UserConfigStore';
-import updateUserConfig, { UserConfigType } from '../api/actions/updateUserConfig';
-import { ApiResponseType } from '../functions/APIClient';
+
+import { OutletContextType } from './Base';
 import { ViewStylesEnum, ViewStylesType } from '../configuration/constants/ViewStyle';
+
+import iconGridView from '/img/icon-gridview.svg';
+import iconListView from '/img/icon-listview.svg';
+import iconAdd from '/img/icon-add.svg';
+import iconFilter from '/img/icon-filter.svg';
 
 type ChannelOverwritesType = {
   download_format: string | null;


### PR DESCRIPTION
### Task Goal
Improve the import organisation in the `Channels.tsx` file. This PR introduces no functional changes.
Now, the imports are grouped according to the following order.

1. React & React Router
2. API & Actions
3. Stores & Hooks
4. Components
5. Types & Constants
6. Assets

Tests:

- [x] Manually verified that the channels page is functioning properly in the local environment.
- [x] run pre-commit hooks 

