### PR TITLE
Fixes error message presented in the settings scheduling frontend when submitting an incorrect cron string

### DIFF
--- a/frontend/src/functions/APIClient.ts
+++ b/frontend/src/functions/APIClient.ts
@@ -49,7 +49,7 @@ const APIClient = async <T>(
     const data = await response.json();
     throw {
       status: response.status,
-      message: data?.message || 'An error occurred while processing the request.',
+      message: data?.message || data?.error || 'An error occurred while processing the request.',
     } as ApiError;
   }
 


### PR DESCRIPTION
When you submit an incorrect cron (for example ``0 5``) the frontend doesn't surface the error message that the API returns, but only the default generic one.
<img width="629" height="310" alt="image" src="https://github.com/user-attachments/assets/1003e0fc-9e34-41af-84ce-445c7a549a04" />

I can see that a proper message is provided by the API:
<img width="332" height="84" alt="image" src="https://github.com/user-attachments/assets/b59c6a9a-6ea4-4b4f-8a32-886742f392a7" />


 This fix makes it surface when the api returns the message in the error attribute and not in the message attribute.
<img width="847" height="540" alt="image" src="https://github.com/user-attachments/assets/40b0b60a-39a8-4b85-9a7e-2630d44685f0" />

I was having this issue, but after confirming I had the TA_HOST correctly defined, I went and inspect the request and saw that it was an easy fix.

You could change the API response, but I don't have enough context on the project to quickly drill down into it, but if you'd rather I go that route I can take a look into it. Let me know!
