### PR TITLE
nesslookalike yt-dlp DL format suggestions update

### DIFF
--- a/frontend/src/pages/SettingsApplication.tsx
+++ b/frontend/src/pages/SettingsApplication.tsx
@@ -396,19 +396,19 @@ const SettingsApplication = () => {
                           <span className="settings-current">
                             {'bestvideo[height<=720]+bestaudio/best[height<=720]'}
                           </span>
-                          : best audio and max video height of 720p.
+                          : best video and audio, max video height of 720p.
                         </li>
                         <li>
                           <span className="settings-current">
                             {'bestvideo[height<=1080]+bestaudio/best[height<=1080]'}
                           </span>
-                          : best audio and max video height of 1080p.
+                          : best video and audio, max video height of 1080p.
                         </li>
                         <li>
                           <span className="settings-current">
                             {'bestvideo[height<=1080][vcodec*=avc1]+bestaudio[acodec*=mp4a]/mp4'}
                           </span>
-                          : Max 1080p video height with iOS compatible video and audio codecs.
+                          : best iOS-compatible video and audio, max video height of 1080p.
                         </li>
                         <li>This can also be configured on a per channel basis.</li>
                         <li>

--- a/frontend/src/pages/SettingsApplication.tsx
+++ b/frontend/src/pages/SettingsApplication.tsx
@@ -396,19 +396,19 @@ const SettingsApplication = () => {
                           <span className="settings-current">
                             {'bestvideo[height<=720]+bestaudio/best[height<=720]'}
                           </span>
-                          : best video and audio, max video height of 720p.
+                          : "best" video and "best" audio (yt-dlp's choice), max video height of 720p.
                         </li>
                         <li>
                           <span className="settings-current">
                             {'bestvideo[height<=1080]+bestaudio/best[height<=1080]'}
                           </span>
-                          : best video and audio, max video height of 1080p.
+                          : "best" video and "best" audio (yt-dlp's choice), max video height of 1080p.
                         </li>
                         <li>
                           <span className="settings-current">
                             {'bestvideo[height<=1080][vcodec*=avc1]+bestaudio[acodec*=mp4a]/mp4'}
                           </span>
-                          : best iOS-compatible video and audio, max video height of 1080p.
+                          : "best" universally iOS-compatible video (forced avc1) and "best" audio (forced mp4a), mp4 container, max video height of 1080p.
                         </li>
                         <li>This can also be configured on a per channel basis.</li>
                         <li>

--- a/frontend/src/pages/SettingsApplication.tsx
+++ b/frontend/src/pages/SettingsApplication.tsx
@@ -410,6 +410,12 @@ const SettingsApplication = () => {
                           </span>
                           : "best" universally iOS-compatible video (forced avc1) and "best" audio (forced mp4a), mp4 container, max video height of 1080p.
                         </li>
+                        <li>
+                          <span className="settings-current">
+                            {'bv*[vcodec~=av01]+ba[acodec~=mp4a]/bv*[vcodec~=av01]+ba/bv*[vcodec~=avc1]+ba[acodec~=mp4a]/bv*[vcodec~=avc1]+ba/bv*+ba/b'}
+                          </span>
+                          : "best" iOS-compatible video (av01, compatible with iPhone 15 Pro and newer) and "best" audio (mp4a), no max video height, with fallback to avc1 and other formats if necessary.
+                        </li>
                         <li>This can also be configured on a per channel basis.</li>
                         <li>
                           More details{' '}


### PR DESCRIPTION
# Summary of proposed DL format suggestions

- standardized existing DL format suggestions text
- added some additional technical details (eg. codec names, pointing out that yt-dlp will make the choice for what "best" means)
- added new DL format suggestion which prioritizes av01/mp4a (then av01/opus, then avc1/mp4a, then avc1/opus, then whatever formats yt-dlp considers "best" which are available)

## Key Changes Made:

- Application Settings page (`frontend/src/pages/SettingsApplication.tsx`)

My hope is that by seeing the additional DL format suggestion, TA users with compatible iOS devices (like myself) save themselves the time and headache of mindlessly downloading a larger number of videos, discovering that the format that yt-dlp considers "best" 90% of the time is YP9 (which is not compatible with iOS devices), then going through a lengthy redownload process of their library.