### PR TITLE
Add tini to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ COPY --from=ffmpeg-builder ./ffprobe/ffprobe /usr/bin/ffprobe
 RUN apt-get clean && apt-get -y update && apt-get -y install --no-install-recommends \
     nginx \
     atomicparsley \
+    tini \
     curl && rm -rf /var/lib/apt/lists/*
 
 # install debug tools for testing environment
@@ -88,4 +89,4 @@ EXPOSE 8000
 
 RUN chmod +x ./run.sh
 
-CMD ["./run.sh"]
+CMD ["/bin/tini", "--", "./run.sh"]


### PR DESCRIPTION
The tubearchivist container currently doesn't gracefully exit when it is stopped.
This is because we have a bash script (run.sh) as our entrypoint for the image.

bash doesn't forward signals received from docker to its children,
which is why the container doesn't stop and is forcefully killed by docker after ~10s.

To fix this we should run an init system such as [tini](https://github.com/krallin/tini) or [dumb-init](https://github.com/Yelp/dumb-init) .

I think tini is the best option for us to use,
since it is already being used by [bbilly1/tubearchivist-es](https://hub.docker.com/layers/bbilly1/tubearchivist-es/8.18.2), 
and is even integrated into docker when you execute [`docker run --init ...`](https://docs.docker.com/reference/cli/docker/container/run/#init).


[Here's](https://github.com/krallin/tini/issues/8#issuecomment-146135930) a comment from the tini creator that goes into more detail about the problem.