### PR TITLE
Fixed: Django Admin page CSS problem #1043

### DIFF
--- a/docker_assets/nginx.conf
+++ b/docker_assets/nginx.conf
@@ -43,7 +43,7 @@ server {
         proxy_pass http://localhost:8080;
     }
 
-    location /static/ {
+    location ^~ /static/ {
         alias /app/staticfiles/;
     }
 


### PR DESCRIPTION
Updated Nginx config to change path priority from 4 to 2. This will affect only the /static/ path. Everything has been tested and is working fine, as we are not using /static/ for another purpose.

more info about change : https://stackoverflow.com/a/45129826

Fixed: Django Admin page CSS problem #1043 

it is not priority fix and no need to create new version, it will be automatically applied in next version.