### PR TITLE
connected redis and es containers via docker network rather over LAN

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     image: redis
     container_name: archivist-redis
     restart: unless-stopped
-#    expose: #uncomment this and below line to expose the redis database directly to the network instead of using a docker network
+#    expose: #uncomment this & below line to expose the redis database directly to the network instead of using a docker network
 #      - "6379"
     volumes:
       - redis:/data
@@ -57,7 +57,7 @@ services:
         hard: -1
     volumes:
       - es:/usr/share/elasticsearch/data    # check for permission error when using bind mount, see readme
-#    expose:  #uncomment this and below line to expose archiveist-es directly to the network instead of using a docker network
+#    expose:  #uncomment this & below line to expose archiveist-es directly to the network instead of using a docker network
 #      - "9200"
     networks:
       - tube_archivist_backend


### PR DESCRIPTION
This change will connect the containers via a docker network rather then have them communicate over the LAN.  This should be faster, more resilient to LAN interruptions, and reduce the load on the local network by keeping traffic off of it that can be done locally.

I left the original ports commented out in case some one has some use case that requires this, so that the ports are documented in the compose file still.  But if you'd prefer I can remove the comments.