### PR TITLE
fix nginx expires config

### DIFF
--- a/docker_assets/nginx.conf
+++ b/docker_assets/nginx.conf
@@ -57,14 +57,13 @@ server {
     location = /index.html {
         add_header Cache-Control "no-store, no-cache, must-revalidate";
         add_header Pragma "no-cache";
-        add_header Expires 0;
         expires 0;
     }
 
     location / {
         add_header Cache-Control "no-store, no-cache, must-revalidate";
         add_header Pragma "no-cache";
-        add_header Expires 0;
+        expires 0;
         try_files $uri $uri/ /index.html =404;
     }
 }


### PR DESCRIPTION
fixes #1111. Tested locally. Preferred method per https://nginx.org/en/docs/http/ngx_http_headers_module.html