### PR TITLE
use appropriate alias creation api

### DIFF
--- a/backend/appsettings/src/index_setup.py
+++ b/backend/appsettings/src/index_setup.py
@@ -292,7 +292,7 @@ class ElasticIndex:
         if settings.DEBUG:
             print(f"create alias with data: {data}")
 
-        response, status_code = ElasticWrap("_alias").put(data=data)
+        response, status_code = ElasticWrap("_aliases").post(data=data)
         if status_code not in [200, 201]:
             print(f"{status_code}: {response}")
             raise ValueError("alias update failed")


### PR DESCRIPTION
As documented as the appropriate way to create an index: https://www.elastic.co/guide/en/elasticsearch/reference/8.19/aliases.html#add-alias

This seems to be required for ES 9.
