### PR TITLE
allow replicas

### DIFF
--- a/backend/appsettings/src/index_setup.py
+++ b/backend/appsettings/src/index_setup.py
@@ -114,6 +114,8 @@ class ElasticIndex:
         now_set = self.details["settings"]["index"]
 
         for key, value in self.expected_set.items():
+            if key == "number_of_replicas":
+                continue
             if key not in now_set.keys():
                 print(key, value)
                 return True


### PR DESCRIPTION
Ignore replica counts while validating indexes. This prevents unnecessary index recreation when replicas are configured, as via `auto_expand.`