### PR TITLE
retry redis on error

### DIFF
--- a/backend/task/celery.py
+++ b/backend/task/celery.py
@@ -19,7 +19,11 @@ def con_parser():
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 app = Celery(
-    "tasks", broker=con_parser(), backend=con_parser(), result_extended=True
+    "tasks",
+    broker=con_parser(),
+    backend=con_parser(),
+    result_extended=True,
+    broker_channel_error_retry=True,
 )
 app.config_from_object(
     "django.conf:settings", namespace=EnvironmentSettings.REDIS_NAME_SPACE


### PR DESCRIPTION
I was seeing the worker process die with some frequency, mostly when my redis cluster switched masters, but sometimes due to transient failures. Some monitoring and/or management of the worker process is probably still called for, but this seems to address most issues.

Not sure why this isn't the celery default, to be honest.

Also experimented with redis sentinel support, since that's something celery supports, but that didn't seem especially helpful.