### PR TITLE
allow disabling auto delete per channel via 0

### DIFF
--- a/backend/download/src/yt_dlp_handler.py
+++ b/backend/download/src/yt_dlp_handler.py
@@ -317,7 +317,7 @@ class DownloadPostProcess(DownloaderBase):
         for channel_id, value in self.channel_overwrites.items():
             if "autodelete_days" in value:
                 autodelete_days = value.get("autodelete_days")
-                if autodelete_days is None:
+                if not autodelete_days:
                     continue
 
                 print(f"{channel_id}: delete older than {autodelete_days}d")


### PR DESCRIPTION
As stands, I believe current behavior is to:

- Allow channels to auto delete after zero days
- Disallow zero day deletion globally
- Provide no way to disable auto deletion on a per-channel basis
- Consider negative numbers valid both globally and per channel, to surprising result

This ought normalize things such that a zero value either globally (existing behavior) or per-channel disables auto deletion, which may or may not match intent.