### PR TITLE
halt downloads on YouTube bot detection

### DIFF
--- a/backend/download/src/yt_dlp_base.py
+++ b/backend/download/src/yt_dlp_base.py
@@ -12,7 +12,7 @@ from os import path
 import yt_dlp
 from appsettings.src.config import AppConfig
 from common.src.env_settings import EnvironmentSettings
-from common.src.helper import deep_merge
+from common.src.helper import deep_merge, rand_sleep
 from common.src.ta_redis import RedisArchivist
 from django.conf import settings
 
@@ -23,6 +23,7 @@ class YtWrap:
     BOT_MESSAGES = [
         "not a bot",
     ]
+    BOT_ERROR_LOG = "YouTube bot detection, abort!"
 
     OBS_BASE = {
         "default_search": "ytsearch",
@@ -99,9 +100,9 @@ class YtWrap:
                 if "Temporary failure in name resolution" in str(err):
                     raise ConnectionError("lost the internet, abort!") from err
                 if any(m in str(err) for m in self.BOT_MESSAGES):
-                    raise ConnectionError(
-                        "YouTube bot detection, abort!"
-                    ) from err
+                    print(self.BOT_ERROR_LOG)
+                    rand_sleep(self.config)
+                    raise ConnectionError(self.BOT_ERROR_LOG) from err
 
                 return False, str(err)
 
@@ -131,9 +132,9 @@ class YtWrap:
                 if "Temporary failure in name resolution" in str(err):
                     raise ConnectionError("lost the internet, abort!") from err
                 if any(m in str(err) for m in self.BOT_MESSAGES):
-                    raise ConnectionError(
-                        "YouTube bot detection, abort!"
-                    ) from err
+                    print(self.BOT_ERROR_LOG)
+                    rand_sleep(self.config)
+                    raise ConnectionError(self.BOT_ERROR_LOG) from err
 
                 return None, str(err)
 


### PR DESCRIPTION
Adds a `stop_on_bot` toggle to Settings > Downloads (default: on).

When YouTube returns "Sign in to confirm you're not a bot", the queue currently marks the video as failed and immediately tries the next one — no delay, no backoff. Every pending video fails in rapid succession, which just reinforces the bot signal.

With this enabled, the queue stops on the first bot error using the same `ConnectionError` pattern as the existing DNS failure check.