### PR TITLE
feat: Send details of videos that were downloaded when sending a "download" notification

### DIFF
--- a/backend/download/src/yt_dlp_handler.py
+++ b/backend/download/src/yt_dlp_handler.py
@@ -55,10 +55,12 @@ class VideoDownloader(DownloaderBase):
         self.obs = False
         self._build_obs()
 
-    def run_queue(self, auto_only=False) -> tuple[int, int]:
+    def run_queue(self, auto_only=False) -> tuple[int, int, list[dict]]:
         """setup download queue in redis loop until no more items"""
         downloaded = 0
         failed = 0
+        downloaded_videos: list[dict] = []
+
         while True:
             video_data = self._get_next(auto_only)
             if self.task.is_stopped() or not video_data:
@@ -87,12 +89,21 @@ class VideoDownloader(DownloaderBase):
             self._notify(video_data, "Move downloaded file to archive")
             self.move_to_archive(vid_dict)
             self._delete_from_pending(youtube_id)
+            downloaded_videos.append(
+                {
+                    "youtube_id": youtube_id,
+                    "title": video_data.get("title"),
+                    "channel_name": video_data.get("channel_name"),
+                    "channel_id": video_data.get("channel_id"),
+                }
+            )
+
             downloaded += 1
 
         # post processing
         DownloadPostProcess(self.task).run()
 
-        return downloaded, failed
+        return downloaded, failed, downloaded_videos
 
     def _notify(self, video_data, message, progress=False):
         """send progress notification to task"""

--- a/backend/task/tasks.py
+++ b/backend/task/tasks.py
@@ -6,6 +6,8 @@ Functionality:
 - handle task locking
 """
 
+import json
+
 from appsettings.src.backup import ElasticBackup
 from appsettings.src.config import ReleaseVersion
 from appsettings.src.filesystem import Scanner
@@ -133,7 +135,9 @@ def download_pending(self, auto_only=False):
     manager.init(self)
     try:
         downloader = VideoDownloader(task=self)
-        downloaded, failed = downloader.run_queue(auto_only=auto_only)
+        downloaded, failed, downloaded_videos = downloader.run_queue(
+            auto_only=auto_only
+        )
 
         if failed:
             print(f"[task][{self.name}] Videos failed, retry.")
@@ -144,7 +148,8 @@ def download_pending(self, auto_only=False):
         raise exc
 
     if downloaded:
-        return f"downloaded {downloaded} video(s)."
+        videos_json = json.dumps(downloaded_videos)
+        return f"downloaded {downloaded} video(s): {videos_json}"
 
     return None
 


### PR DESCRIPTION
I wanted to use the "download" notification to run a script on a video finishing downloading, but the notification just includes "download 1 video(s)" with no details about which videos were downloaded.

I changed the `run_queue` function to return a list of downloaded video details. The fields `youtube_id`, `title`, `channel_name`, and `channel_id` are stored for each video downloaded, and then a json blob is sent in addition to the message.

I've been making this change manually to the last few releases, so I thought I would submit here in case anyone else finds this interesting. Hopefully it is considered to be merged so I can stop doing this myself.
