### PR TITLE
Fix KeyError 'entries' when YouTube redirects channel ID (#1165)

### DIFF
--- a/backend/channel/src/remote_query.py
+++ b/backend/channel/src/remote_query.py
@@ -91,6 +91,27 @@ class VideoQueryBuilder:
         return (vid_type, None)
 
 
+def _resolve_channel_query(
+    channel_id: str,
+    url: str,
+    obs: dict,
+    config: AppConfigType,
+) -> dict | None:
+    """extract channel query, following a redirect if yt-dlp returns one"""
+    channel_query, _ = YtWrap(obs, config).extract(url)
+    if not channel_query:
+        return None
+
+    # yt-dlp may return a redirect (_type: 'url') instead of a playlist
+    # when YouTube redirects a channel ID to another. Follow the redirect.
+    if channel_query.get("_type") == "url" and channel_query.get("url"):
+        redirect_url = channel_query["url"]
+        print(f"{channel_id}: following channel redirect to {redirect_url}")
+        channel_query, _ = YtWrap(obs, config).extract(redirect_url)
+
+    return channel_query or None
+
+
 def get_last_channel_videos(
     channel_id: str,
     config: AppConfigType,
@@ -127,8 +148,12 @@ def get_last_channel_videos(
             obs["playlist_items"] = f":{limit_amount}:1"
 
         url = f"https://www.youtube.com/channel/{channel_id}/{vid_type}"
-        channel_query, _ = YtWrap(obs, config).extract(url)
+        channel_query = _resolve_channel_query(channel_id, url, obs, config)
         if not channel_query:
+            continue
+
+        if "entries" not in channel_query:
+            print(f"{channel_id}: no entries found for {vid_type}, skipping")
             continue
 
         for entry in channel_query["entries"]:


### PR DESCRIPTION
Fixes #1165

When yt-dlp extracts a channel tab URL for a channel that YouTube has redirected to a different channel ID, it returns a `_type: 'url'` redirect object rather than a playlist. The previous code unconditionally accessed `channel_query["entries"]`, causing a KeyError crash that stalls the entire download queue.

Fix: after extracting a channel tab URL, check if the result is a redirect and re-extract using the resolved URL. Also adds a guard for missing `entries` to handle any other unexpected response shapes gracefully.

Reproduced with any video from channel UCHcMtE3EiKmqrJZBZyUBuRQ (Adult Swim Europe), which YouTube redirects to UCgPClNr5VSYC3syrDUIlzLw (Adult Swim).
