### PR TITLE
Casting subtitles hotfix

### DIFF
--- a/docker_assets/nginx.conf
+++ b/docker_assets/nginx.conf
@@ -30,6 +30,7 @@ server {
         alias /youtube/;
         types {
             video/mp4 mp4;
+            text/vtt vtt;
         }
     }
     

--- a/frontend/src/components/GoogleCast.tsx
+++ b/frontend/src/components/GoogleCast.tsx
@@ -165,7 +165,8 @@ const GoogleCast = ({ video, setRefresh, onWatchStateChanged }: GoogleCastProps)
       for (let i = 0; i < videoSubtitles.length; i++) {
         const subtitle = new chrome.cast.media.Track(i, chrome.cast.media.TrackType.TEXT);
 
-        subtitle.trackContentId = videoSubtitles[i].media_url;
+        // subtitle.trackContentId = videoSubtitles[i].media_url;
+        subtitle.trackContentId = `${getURL()}${videoSubtitles[i].media_url}`;
         subtitle.trackContentType = 'text/vtt';
         subtitle.subtype = chrome.cast.media.TextTrackType.SUBTITLES;
         subtitle.name = videoSubtitles[i].name;
@@ -188,6 +189,9 @@ const GoogleCast = ({ video, setRefresh, onWatchStateChanged }: GoogleCastProps)
     // request.queueData = new chrome.cast.media.QueueData(); // See https://developers.google.com/cast/docs/reference/web_sender/chrome.cast.media.QueueData for playlist support.
     request.currentTime = shiftCurrentTime(video?.player?.position); // Set video start position based on the browser video position
     // request.activeTrackIds = contentActiveSubtitle; // Set active subtitle based on video player
+    if (contentSubtitles.length > 0) {
+      request.activeTrackIds = [0];
+    }
 
     castSession.loadMedia(request).then(
       function () {

--- a/frontend/src/components/GoogleCast.tsx
+++ b/frontend/src/components/GoogleCast.tsx
@@ -165,7 +165,6 @@ const GoogleCast = ({ video, setRefresh, onWatchStateChanged }: GoogleCastProps)
       for (let i = 0; i < videoSubtitles.length; i++) {
         const subtitle = new chrome.cast.media.Track(i, chrome.cast.media.TrackType.TEXT);
 
-        // subtitle.trackContentId = videoSubtitles[i].media_url;
         subtitle.trackContentId = `${getURL()}${videoSubtitles[i].media_url}`;
         subtitle.trackContentType = 'text/vtt';
         subtitle.subtype = chrome.cast.media.TextTrackType.SUBTITLES;


### PR DESCRIPTION
Subtitles work in the web player but never render when casting — the receiver never fetches the VTT.

Two causes:

- GoogleCast.tsx uses a relative subtitle trackContentId (resolves against the receiver's origin, not the TA host). activeTrackIds is never activated and needs to be, in order for the casted device to even be signaled to send the VTT request.

- The /youtube/ nginx location maps only mp4 in its types block, so .vtt is served as application/octet-stream and isn't rendered. The /media/ block already has the text/vtt mapping.