### PR TITLE
fix: migrate channel_tags boolean to empty list on startup

### DIFF
--- a/backend/config/management/commands/ta_startup.py
+++ b/backend/config/management/commands/ta_startup.py
@@ -64,6 +64,7 @@ class Command(BaseCommand):
         self._mig_fix_playlist_description()
         self._mig_fix_missing_stats()
         self._mig_fix_channel_art_types()
+        self._mig_fix_channel_tags()
         self._mig_fix_channel_description()
         self._mig_fix_video_description()
 
@@ -425,6 +426,36 @@ class Command(BaseCommand):
                 query={"term": {f"channel.{field}": {"value": False}}},
                 script={"source": source, "lang": "painless"},
             )
+
+    def _mig_fix_channel_tags(self) -> None:
+        """migrate: fix channel_tags stored as boolean instead of list"""
+        # Boolean false is not indexable as keyword, so term queries don't
+        # match it; use match_all + Painless instanceof check instead.
+        channel_script = (
+            "if (ctx._source.containsKey('channel_tags')"
+            " && !(ctx._source.channel_tags instanceof List))"
+            " { ctx._source.channel_tags = []; }"
+            " else { ctx.op = 'noop'; }"
+        )
+        self._run_migration(
+            index_name="ta_channel",
+            desc="fix channel_tags data type in channel index",
+            query={"match_all": {}},
+            script={"source": channel_script, "lang": "painless"},
+        )
+        video_script = (
+            "if (ctx._source.containsKey('channel')"
+            " && ctx._source.channel.containsKey('channel_tags')"
+            " && !(ctx._source.channel.channel_tags instanceof List))"
+            " { ctx._source.channel.channel_tags = []; }"
+            " else { ctx.op = 'noop'; }"
+        )
+        self._run_migration(
+            index_name="ta_video",
+            desc="fix channel_tags data type in video index",
+            query={"match_all": {}},
+            script={"source": video_script, "lang": "painless"},
+        )
 
     def _mig_fix_channel_description(self) -> None:
         """migrate from 0.5.8 to 0.5.9, fix channel desc null value"""


### PR DESCRIPTION
## Problem

Channels without tags have `channel_tags` stored as boolean `false` in Elasticsearch rather than an empty list `[]`. The strict `ListField` serializer raises `TypeError: 'bool' object is not iterable` when rendering these records, causing:

- HTTP 500 on `GET /api/channel/` and `GET /api/video/`
- Perpetual loading spinner on the Channels and Home pages
- No error visible in logs (DEBUG is off in production)

This is the root cause reported in #1042, #1063, #1067, and #1097. The videos endpoint fails because video documents embed channel metadata, so the bad `channel_tags` value propagates there too.

## Why the existing pattern doesn't work here

The migrations for artwork URL fields (`_mig_fix_channel_art_types`) use a `term: false` query to find affected documents. That works for those fields because Elasticsearch can index and query their stored values. For `channel_tags` — mapped as `keyword` — Elasticsearch does not index a boolean `false` value as a keyword term, so `term: false` matches nothing and the documents are silently skipped.

## Fix

Use `match_all` with a Painless `instanceof` check in the update script, and `ctx.op = 'noop'` to skip documents that are already correct. This is guaranteed to find and fix the affected documents regardless of how the boolean was indexed, and is safe to run repeatedly.

Two passes are made:
1. `ta_channel` index — sets `channel_tags = []` where it is not already a list
2. `ta_video` index — fixes the embedded `channel.channel_tags` copy in video documents

## Testing

Reproduced on a live instance running v0.5.10 with data going back to before v0.5.5. After applying the equivalent ES `update_by_query` calls manually:
- `GET /api/channel/` returned all 27 channels correctly
- `GET /api/video/` returned all 901 videos correctly
- UI Channels and Home pages loaded without spinning

🤖 Generated with [Claude Code](https://claude.com/claude-code)