### PR TITLE
Seek to correct location on close and reopen video

### DIFF
--- a/frontend/src/components/EmbeddableVideoPlayer.tsx
+++ b/frontend/src/components/EmbeddableVideoPlayer.tsx
@@ -38,6 +38,13 @@ const EmbeddableVideoPlayer = ({ videoId }: EmbeddableVideoPlayerProps) => {
   const { data: videoResponseData } = videoResponse ?? {};
 
   useEffect(() => {
+    if (!videoId) {
+      setVideoResponse(undefined);
+      setPlaylists(undefined);
+    }
+  }, [videoId]);
+
+  useEffect(() => {
     (async () => {
       if (!videoId) {
         return;

--- a/frontend/src/components/EmbeddableVideoPlayer.tsx
+++ b/frontend/src/components/EmbeddableVideoPlayer.tsx
@@ -37,12 +37,14 @@ const EmbeddableVideoPlayer = ({ videoId }: EmbeddableVideoPlayerProps) => {
 
   const { data: videoResponseData } = videoResponse ?? {};
 
-  useEffect(() => {
+  const [prevVideoId, setPrevVideoId] = useState(videoId);
+  if (videoId !== prevVideoId) {
+    setPrevVideoId(videoId);
     if (!videoId) {
       setVideoResponse(undefined);
       setPlaylists(undefined);
     }
-  }, [videoId]);
+  }
 
   useEffect(() => {
     (async () => {


### PR DESCRIPTION
There was a bug @h-quer found wherein: 

> When watching a video with the web UI, closing that video, and clicking it again to watch without closing/refreshing the browser window, the previous watch progress gets discarded and the video plays from the initial position (since last browser refresh/page open) again.

Resetting the `videoResponse` on component teardown (unsetting `videoId`) resolves this to avoid stale cached `videoResponse` overriding the updated progress. 