### PR TITLE
Don't stop processing downloads if channel has been deleted

### DIFF
--- a/backend/download/src/yt_dlp_handler.py
+++ b/backend/download/src/yt_dlp_handler.py
@@ -426,9 +426,21 @@ class DownloadPostProcess(DownloaderBase):
             if not channel_id:
                 break
 
-            channel = YoutubeChannel(channel_id)
-            channel.get_from_es()
-            overwrites = channel.get_overwrites()
+            try:
+                channel = YoutubeChannel(channel_id)
+                channel.get_from_es()
+                if not channel.json_data:
+                    raise ValueError("no json data extracted for channel")
+
+                overwrites = channel.get_overwrites()
+            except ValueError as err:
+                message = [f"{channel_id}: skip deleted channel", str(err)]
+                print(message)
+                if self.task:
+                    self.task.send_progress(message)
+
+                continue
+
             if overwrites.get("index_playlists"):
                 channel.get_all_playlists()
                 to_add = [i[0] for i in channel.all_playlists]
@@ -457,11 +469,22 @@ class DownloadPostProcess(DownloaderBase):
             if not playlist_id or not idx or not total:
                 break
 
-            playlist = YoutubePlaylist(playlist_id)
-            playlist.get_from_es()
-            playlist.add_vids_to_playlist()
-            playlist.remove_vids_from_playlist()
-            playlist.match_local()
+            try:
+                playlist = YoutubePlaylist(playlist_id)
+                playlist.get_from_es()
+                if not playlist.json_data:
+                    raise ValueError("no json data extracted for playlist")
+
+                playlist.add_vids_to_playlist()
+                playlist.remove_vids_from_playlist()
+                playlist.match_local()
+            except ValueError as err:
+                message = [f"{playlist_id}: skip deleted playlist", str(err)]
+                print(message)
+                if self.task:
+                    self.task.send_progress(message)
+
+                continue
 
             if not self.task:
                 continue

--- a/backend/download/src/yt_dlp_handler.py
+++ b/backend/download/src/yt_dlp_handler.py
@@ -426,21 +426,12 @@ class DownloadPostProcess(DownloaderBase):
             if not channel_id:
                 break
 
-            try:
-                channel = YoutubeChannel(channel_id)
-                channel.get_from_es()
-                if not channel.json_data:
-                    raise ValueError("no json data extracted for channel")
-
-                overwrites = channel.get_overwrites()
-            except ValueError as err:
-                message = [f"{channel_id}: skip deleted channel", str(err)]
-                print(message)
-                if self.task:
-                    self.task.send_progress(message)
-
+            channel = YoutubeChannel(channel_id)
+            channel.get_from_es()
+            if not channel.json_data:
                 continue
 
+            overwrites = channel.get_overwrites()
             if overwrites.get("index_playlists"):
                 channel.get_all_playlists()
                 to_add = [i[0] for i in channel.all_playlists]
@@ -469,22 +460,14 @@ class DownloadPostProcess(DownloaderBase):
             if not playlist_id or not idx or not total:
                 break
 
-            try:
-                playlist = YoutubePlaylist(playlist_id)
-                playlist.get_from_es()
-                if not playlist.json_data:
-                    raise ValueError("no json data extracted for playlist")
-
-                playlist.add_vids_to_playlist()
-                playlist.remove_vids_from_playlist()
-                playlist.match_local()
-            except ValueError as err:
-                message = [f"{playlist_id}: skip deleted playlist", str(err)]
-                print(message)
-                if self.task:
-                    self.task.send_progress(message)
-
+            playlist = YoutubePlaylist(playlist_id)
+            playlist.get_from_es()
+            if not playlist.json_data:
                 continue
+
+            playlist.add_vids_to_playlist()
+            playlist.remove_vids_from_playlist()
+            playlist.match_local()
 
             if not self.task:
                 continue

--- a/backend/download/src/yt_dlp_handler.py
+++ b/backend/download/src/yt_dlp_handler.py
@@ -429,6 +429,7 @@ class DownloadPostProcess(DownloaderBase):
             channel = YoutubeChannel(channel_id)
             channel.get_from_es()
             if not channel.json_data:
+                print(f"{channel_id}: skip failed channel import")
                 continue
 
             overwrites = channel.get_overwrites()
@@ -463,6 +464,7 @@ class DownloadPostProcess(DownloaderBase):
             playlist = YoutubePlaylist(playlist_id)
             playlist.get_from_es()
             if not playlist.json_data:
+                print(f"{playlist_id}: skip failed playlist import")
                 continue
 
             playlist.add_vids_to_playlist()


### PR DESCRIPTION
Addresses https://github.com/tubearchivist/tubearchivist/issues/1103 and another potential bug by adding similar error handling used elsewhere, checking to ensure there's `json_data` on the given object before processing it, preventing an unhandled python `AttributeError`. 

