### PR TITLE
fix(frontend): display audio/video bitrate in correct SI units (#1164)

### DIFF
--- a/frontend/src/components/VideoListItemTable.tsx
+++ b/frontend/src/components/VideoListItemTable.tsx
@@ -3,12 +3,12 @@ import Routes from '../configuration/routes/RouteList';
 import { VideoType } from '../pages/Home';
 import { ViewStylesType } from '../configuration/constants/ViewStyle';
 import humanFileSize from '../functions/humanFileSize';
+import humanBitrate from '../functions/humanBitrate';
 import { FileSizeUnits } from '../api/actions/updateUserConfig';
 import { useUserConfigStore } from '../stores/UserConfigStore';
 import { useVideoSelectionStore } from '../stores/VideoSelectionStore';
 import iconChecked from '/img/icon-seen.svg';
 import iconUnchecked from '/img/icon-unseen.svg';
-import bitsToBytes from '../functions/bitsToBytes';
 
 const StreamsTypeEmun = {
   Video: 'video',
@@ -98,9 +98,9 @@ const VideoListItemTable = ({ videoList, viewStyle }: VideoListItemProps) => {
                 <td>{`${videoStream?.width || '-'}x${videoStream?.height || '-'}`}</td>
                 <td>{humanFileSize(media_size, useSiUnits)}</td>
                 <td>{videoStream?.codec || '-'}</td>
-                <td>{humanFileSize(bitsToBytes(videoStream?.bitrate || 0), useSiUnits)}</td>
+                <td>{humanBitrate(videoStream?.bitrate || 0)}</td>
                 <td>{audioStream?.codec || '-'}</td>
-                <td>{humanFileSize(bitsToBytes(audioStream?.bitrate || 0), useSiUnits)}</td>
+                <td>{humanBitrate(audioStream?.bitrate || 0)}</td>
               </tr>
             );
           })}

--- a/frontend/src/functions/humanBitrate.ts
+++ b/frontend/src/functions/humanBitrate.ts
@@ -1,0 +1,44 @@
+/**
+ * Format a bitrate (in bits per second) as human-readable text.
+ *
+ * Bitrate values from yt-dlp come in bits per second. This helper formats
+ * them using SI powers of 1000 (kbps, Mbps, Gbps) — the standard for
+ * bit-rate display, where 1 kbps = 1000 bits per second.
+ *
+ * Note: this intentionally does NOT use the IEC "Kib/s" unit, since
+ * network bitrates (and yt-dlp's own `--format-sort bitrate` values)
+ * are universally expressed in SI decimal units in the wild.
+ *
+ * @param bitsPerSecond Bitrate in bits per second.
+ * @param dp Number of decimal places to display. Default 1.
+ *
+ * @return Formatted string ending in the unit (e.g. "1.5 Mbps").
+ */
+function humanBitrate(bitsPerSecond: number, dp = 1): string {
+  if (!isFinite(bitsPerSecond) || bitsPerSecond < 0) {
+    return '-';
+  }
+  if (bitsPerSecond === 0) {
+    return '0 bps';
+  }
+
+  const thresh = 1000;
+  const units = ['bps', 'kbps', 'Mbps', 'Gbps', 'Tbps'];
+
+  if (Math.abs(bitsPerSecond) < thresh) {
+    return bitsPerSecond + ' bps';
+  }
+
+  let value = bitsPerSecond;
+  let u = 0;
+  const r = 10 ** dp;
+
+  do {
+    value /= thresh;
+    ++u;
+  } while (Math.round(Math.abs(value) * r) / r >= thresh && u < units.length - 1);
+
+  return value.toFixed(dp) + ' ' + units[u];
+}
+
+export default humanBitrate;

--- a/frontend/src/pages/Video.tsx
+++ b/frontend/src/pages/Video.tsx
@@ -16,6 +16,7 @@ import loadSimilarVideosById from '../api/loader/loadSimilarVideosById';
 import VideoList from '../components/VideoList';
 import updateWatchedState from '../api/actions/updateWatchedState';
 import humanFileSize from '../functions/humanFileSize';
+import humanBitrate from '../functions/humanBitrate';
 import ScrollToTopOnNavigate from '../components/ScrollToTop';
 import ChannelOverview from '../components/ChannelOverview';
 import deleteVideo from '../api/actions/deleteVideo';
@@ -45,7 +46,6 @@ import NotFound from './NotFound';
 import { ApiResponseType } from '../functions/APIClient';
 import VideoThumbnail from '../components/VideoThumbail';
 import { ViewStylesEnum, ViewStylesType } from '../configuration/constants/ViewStyle';
-import bitsToBytes from '../functions/bitsToBytes';
 
 const isInPlaylist = (videoId: string, playlist: PlaylistType) => {
   return playlist.playlist_entries.some(entry => {
@@ -461,7 +461,7 @@ const Video = () => {
                 return (
                   <p key={stream.index}>
                     {capitalizeFirstLetter(stream.type)}: {stream.codec}{' '}
-                    {humanFileSize(bitsToBytes(stream.bitrate), useSiUnits)}/s
+                    {humanBitrate(stream.bitrate)}
                     {stream.width && (
                       <>
                         <span className="space-carrot">|</span> {stream.width}x{stream.height}


### PR DESCRIPTION
## Problem

Issue #1164 — the audio/video bitrate shown on the video page and in the table view was being formatted with the byte-size helper after converting bits→bytes, then suffixed with `/s`. The result was misleading labels like `984 KiB/s` for a value that is actually `984 * 1024 / 8 = 125952 bytes/sec ≈ 1008 kbps` — a per-second *bit* rate.

For a video with combined `984 + 114 = 1098 kbps` audio+video stream selection, the page was rendering `984 KiB/s` plus `114 KiB/s` instead of the correct `984 kbps` plus `114 kbps` (or `1.1 Mbps` total). It mixed bit-units with byte-units and silently rounded the value down by ~9% in the process.

## Fix

- Add `frontend/src/functions/humanBitrate.ts` — a dedicated formatter that takes a `bitsPerSecond` value and returns a string in SI decimal units (`bps`, `kbps`, `Mbps`, `Gbps`, `Tbps`), matching the convention yt-dlp itself uses for `--format-sort bitrate`.
- Switch the bitrate cells in `VideoListItemTable.tsx` and the stream-info line in `Video.tsx` to call `humanBitrate(stream.bitrate)` directly. The `/s` suffix is gone because the unit (`kbps`) already implies per-second.
- Drop the now-unused `bitsToBytes` import from `Video.tsx`.

`bitsToBytes` is still exported in case anyone else needs byte-size conversion elsewhere — it's a generic helper, only the bitrate display was misusing it.

## How to verify

1. Open any video page (the bug reporter used id `HJYLROgd6IA`).
2. Look at the audio and video bitrate rows in the info box.
3. Before this fix: `Video: avc1 122 KiB/s` and `Audio: mp4a 14 KiB/s`.
4. After this fix: `Video: avc1 984 kbps` and `Audio: mp4a 114 kbps`.
5. Combined bitrate ≈ `1.1 Mbps`, which matches `yt-dlp -F` output for that video.

Local typecheck (`tsc --noEmit`), production build, and `eslint .` all pass on the patched tree.