### PR TITLE
Remove subtitle_key from log

### DIFF
--- a/backend/video/src/subtitle.py
+++ b/backend/video/src/subtitle.py
@@ -193,7 +193,7 @@ class YoutubeSubtitle:
             return None
 
         if not response.text:
-            print(f"{subtitle_key}: skip empty subtitle")
+            print("skip empty subtitle")
             rand_sleep(self.video.config)
             return None
 

--- a/backend/video/src/subtitle.py
+++ b/backend/video/src/subtitle.py
@@ -185,15 +185,15 @@ class YoutubeSubtitle:
 
         response = requests.get(url, **request_kwargs)
 
+        subtitle_key = f"{self.video.youtube_id}-{lang}"
         if not response.ok:
-            subtitle_key = f"{self.video.youtube_id}-{lang}"
             print(f"{subtitle_key}: failed to download subtitle")
             print(response.text)
             rand_sleep(self.video.config)
             return None
 
         if not response.text:
-            print("skip empty subtitle")
+            print(f"{subtitle_key}: skip empty subtitle")
             rand_sleep(self.video.config)
             return None
 


### PR DESCRIPTION
subtitle_key is not available to log if there is no response text
This fixes the visible issue with #1199

Check the box, if you are a human.

## I'm a human

- [x ] I confirm that I'm a human opening this PR.
