### PR TITLE
feat(ui): add missing units to download speed

### DIFF
--- a/frontend/src/pages/SettingsApplication.tsx
+++ b/frontend/src/pages/SettingsApplication.tsx
@@ -320,7 +320,7 @@ const SettingsApplication = () => {
               )}
               <div className="settings-box-wrapper">
                 <div>
-                  <p>Download Speed limit</p>
+                  <p>Download Speed limit (B/s)</p>
                 </div>
                 <InputConfig
                   type="number"
@@ -333,7 +333,7 @@ const SettingsApplication = () => {
               </div>
               <div className="settings-box-wrapper">
                 <div>
-                  <p>Throttled rate limit</p>
+                  <p>Throttled rate limit (B/s)</p>
                 </div>
                 <InputConfig
                   type="number"

--- a/frontend/src/pages/SettingsApplication.tsx
+++ b/frontend/src/pages/SettingsApplication.tsx
@@ -346,7 +346,7 @@ const SettingsApplication = () => {
               </div>
               <div className="settings-box-wrapper">
                 <div>
-                  <p>Sleep interval</p>
+                  <p>Sleep interval (s)</p>
                 </div>
                 <InputConfig
                   type="number"


### PR DESCRIPTION
makes it more clear in what kind of unit the download speed is described as, some applications would limit in MiB/s, some in KiB/s, we (or yt-dlp) chose B/s


## I'm a human

- [x] I confirm that I'm a human opening this PR.
