### PR TITLE
ci: set least-privilege token permissions on CI workflows (#1)

### DIFF
--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - '**/*.py'
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a top-level 'permissions: contents: read' to the pre-commit and unit-test workflows. Both jobs only check out the repo and run lint/tests (no registry writes or publishing), so a read-only `GITHUB_TOKEN` is sufficient. No behavior change.

## I'm a human

- [X] I confirm that I'm a human opening this PR.
